### PR TITLE
Make large numbers/durations human-friendly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kneasle_ringing_utils"
+version = "0.0.0"
+dependencies = [
+ "number_prefix",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +580,7 @@ dependencies = [
  "colored",
  "difference",
  "itertools",
+ "kneasle_ringing_utils",
  "log",
  "monument",
  "ordered-float",
@@ -627,6 +635,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
-members = ["bellframe", "monument/lib", "monument/cli"]
+members = ["utils", "bellframe", "monument/lib", "monument/cli"]
 
+# Do some optimisation for debug builds.  -O2 is still fast enough, but makes things like file IO
+# much faster.
 [profile.dev]
 opt-level = 2

--- a/README.md
+++ b/README.md
@@ -4,12 +4,18 @@ A single repository containing all my Rust projects related to
 [change ringing](https://en.wikipedia.org/wiki/Change_ringing).  All are under the MIT license.
 
 As far as cargo/rust is concerened, this repository is one single workspace consisting of many
-separate crates.  Each project/library lives in its own directory and may correspond to multiple Rust crates:
+separate crates.  Each project/library lives in its own directory and may correspond to multiple
+Rust crates.  Having all of these in the same repository ensures that all code is kept synchronised,
+and CI builds don't have to worry about dependency shenanigans.
+
+### Projects
+
 - [`Monument`](monument/): A fast and flexible library & CLI app for generating compositions
 - [`Jigsaw`](https://github.com/kneasle/jigsaw) (yet to be moved here): A visual tool for
   experimenting with compositions
+
+### Libraries
 - [`BellFrame`](bellframe/): A 'standard library' containing robust primitives useful for processing
   compositions in Rust.  Used by all other projects.
-
-Having all of these in the same repository ensures that all code is kept synchronised, and CI builds
-don't have to worry about dependency shenanigans.
+- [`utils`](utils/): Small utilities which aren't specific to ringing.  Mostly extensions to the
+  standard library, with few or no dependencies.

--- a/monument/cli/Cargo.toml
+++ b/monument/cli/Cargo.toml
@@ -13,6 +13,7 @@ bellframe = { version = "0.6.0", path = "../../bellframe/", features = ["serde"]
 itertools = "0.10"
 log = "0.4"
 monument = { version = "0.2.1", path = "../lib/" }
+ringing_utils = { version = "0.0.0", package = "kneasle_ringing_utils", path = "../../utils/" }
 serde = { version = "1.0", features = ["derive"] }
 simple_logger = "2.1"
 structopt = "0.3"

--- a/monument/cli/src/lib.rs
+++ b/monument/cli/src/lib.rs
@@ -25,6 +25,7 @@ use bellframe::{
 };
 use log::{log_enabled, LevelFilter};
 use monument::{Comp, Config, Progress, Query, QueryUpdate};
+use ringing_utils::{BigNumInt, PrettyDuration};
 use simple_logger::SimpleLogger;
 use spec::Spec;
 
@@ -118,7 +119,7 @@ impl QueryResult {
         for c in &self.comps {
             println!("{}", c.long_string());
         }
-        println!("Search completed in {:?}", self.duration);
+        println!("Search completed in {}", PrettyDuration(self.duration));
     }
 }
 
@@ -241,7 +242,10 @@ impl UpdateLogger {
         write!(
             buf,
             "    {} iters, {} items in queue, avg/max len {:.0}/{}",
-            p.iter_count, p.queue_len, p.avg_length, p.max_length
+            BigNumInt(p.iter_count),
+            BigNumInt(p.queue_len),
+            p.avg_length,
+            p.max_length
         )
         .unwrap();
         if self.is_truncating_queue {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "kneasle_ringing_utils"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+number_prefix = "0.4"

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,4 @@
+# Sink
+
+A 'kitchen-sink' crate, containing various useful non-ringing-related utilities that are used by
+other crates but don't belong in BellFrame.

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,0 +1,162 @@
+//! A set of useful utilities which are used by my ringing projects but aren't directly related to
+//! ringing.  The name `kneasle_ringing_utils` is intentionally obscure; this isn't meant for
+//! public use but needs to be on crates.io so that Monument can be installed with `cargo install`.
+//! I don't want to clutter up possibly useful names on crates.io, hence the obscure name.
+
+use std::{
+    fmt::{Display, Formatter},
+    time::Duration,
+};
+
+use number_prefix::NumberPrefix;
+
+/// A wrapper around [`Duration`] which formats in a way that's easy to digest for all values,
+/// whether that's nanoseconds or many days.
+///
+/// # Example
+/// ```
+/// use std::time::Duration;
+/// use kneasle_ringing_utils::PrettyDuration;
+///
+/// // Really short time
+/// assert_eq!(
+///     format!("{}", PrettyDuration(Duration::from_secs_f32(0.00_00123451))),
+///     "12.35µs"
+/// );
+/// assert_eq!(
+///     format!("{}", PrettyDuration(Duration::from_secs_f32(10234.0))),
+///     "2h 50m 34.00s"
+/// );
+/// ```
+#[derive(Clone, Copy)]
+pub struct PrettyDuration(pub Duration);
+
+impl Display for PrettyDuration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let total_secs = self.0.as_secs_f64();
+        if self.0 == Duration::ZERO {
+            write!(f, "0.00s") // `Duration` gives this "0.00ns", which IMO is confusing
+        } else if total_secs < 60.0 {
+            // If the Duration is shorter than a minute, then using duration's 'debug' output to 2
+            // decimal places does a pretty nice job
+            write!(f, "{:.2?}", self.0)
+        } else {
+            // If the Duration is longer than a minute, we split it into days, hours, mins and (some
+            // decimal number of) seconds like `#d #h #m #.#s`.  Again, the seconds goes to 2 decimal
+            // places
+
+            // Split out the (integer) number of minutes
+            let total_mins = (total_secs / 60.0).floor() as usize;
+            let num_secs = total_secs - total_mins as f64 * 60.0;
+            // Split out the (integer) number of hours
+            let total_hours = total_mins / 60;
+            let num_mins = total_mins % 60;
+            // Split out the (integer) number of days
+            let total_days = total_hours / 24;
+            let num_hours = total_hours % 24;
+
+            // Generate the format string
+            if total_days > 0 {
+                write!(f, "{}d ", total_days)?;
+            }
+            if total_hours > 0 {
+                write!(f, "{}h ", num_hours)?;
+            }
+            if total_mins > 0 {
+                write!(f, "{}m ", num_mins)?;
+            }
+            write!(f, "{:.2}s", num_secs)
+        }
+    }
+}
+
+/// A wrapper over integers where [`Display`] formats the number suffixed with a multiplier
+/// (e.g. `M` or `G` for millions or billions).  This differs from [`BigNumFloat`] because it will
+/// never output a decimal number of values.
+#[derive(Clone, Copy)]
+pub struct BigNumInt(pub usize);
+
+impl Display for BigNumInt {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match NumberPrefix::decimal(self.0 as f64) {
+            NumberPrefix::Standalone(n) => write!(f, "{:.0}", n),
+            NumberPrefix::Prefixed(prefix, n) => write!(f, "{:.2}{}", n, prefix),
+        }
+    }
+}
+
+/// A wrapper over floats where [`Display`] formats the number suffixed with a multiplier
+/// (e.g. `M` or `G` for millions or billions).  This differs from [`BigNumInt`] because it will
+/// output up to 3 decimal places if the number is small enough
+pub struct BigNumFloat(pub f64);
+
+impl Display for BigNumFloat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match NumberPrefix::decimal(self.0) {
+            NumberPrefix::Standalone(n) => write!(f, "{:.1}", n),
+            NumberPrefix::Prefixed(prefix, n) => write!(f, "{:.2}{}", n, prefix),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pretty_duration() {
+        #[track_caller]
+        fn check(secs: f64, output: &str) {
+            let dur = Duration::from_secs_f64(secs);
+            assert_eq!(format!("{}", PrettyDuration(dur)), output);
+        }
+
+        check(0.0, "0.00s");
+        check(0.000_000_031_24156, "31.00ns"); // `Duration` is only accurate to the nearest nanosecond
+        check(0.000_312_4156, "312.42µs");
+        check(0.001_23015456, "1.23ms");
+        check(5.2321345, "5.23s");
+        check(60.0, "1m 0.00s");
+        check(60.0005, "1m 0.00s");
+        check(60.5, "1m 0.50s");
+        check(3600.0, "1h 0m 0.00s");
+        check(3600.5, "1h 0m 0.50s");
+        check(8247.15213, "2h 17m 27.15s");
+        check(18247.15213, "5h 4m 7.15s");
+        check(118247.15213, "1d 8h 50m 47.15s");
+    }
+
+    #[test]
+    fn big_num_int() {
+        #[track_caller]
+        fn check(v: usize, output: &str) {
+            assert_eq!(format!("{}", BigNumInt(v)), output);
+        }
+
+        check(0, "0");
+        check(102, "102");
+        check(1_234, "1.23k");
+        check(12_357_123, "12.36M");
+        check(1_312_357_123, "1.31G");
+        check(56_312_357_123, "56.31G");
+        check(1_456_312_357_123, "1.46T");
+    }
+
+    #[test]
+    fn big_num_float() {
+        #[track_caller]
+        fn check(v: f64, output: &str) {
+            assert_eq!(format!("{}", BigNumFloat(v)), output);
+        }
+
+        check(-100.0, "-100.0");
+        check(0.0, "0.0");
+        check(0.001_35, "0.0"); // Small numbers don't get prefixes
+        check(102.0, "102.0");
+        check(1_234.0, "1.23k");
+        check(12_357_123.0, "12.36M");
+        check(1_312_357_123.0, "1.31G");
+        check(56_312_357_123.0, "56.31G");
+        check(1_456_312_357_123.0, "1.46T");
+    }
+}


### PR DESCRIPTION
Prevents people from accidentally misreading them.  For example `Search completed in 9m 44.97s` instead of `Search completed in 584.97s`, and `1.30M iters, 9.98M items in queue, avg/max len 2716/4256`.