### PR TITLE
Run CI tests in debug mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,16 +11,13 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      # Note that we run tests in release mode because doing so makes loading the CC method library much faster
-      run: cargo build --release --verbose
+      run: cargo build --verbose
     - name: Run tests
-      run: cargo test --release --verbose
+      run: cargo test --verbose
     - name: Run clippy
       run: cargo clippy --no-deps
     - name: Check formatting


### PR DESCRIPTION
This should hopefully make the CI builds run faster, since the current time of ~6m seems excessive (even for Rust).  There's also a chance that we'll hit a debug check and find a bug that otherwise would have gone undetected.