### PR TITLE
Add README pages for Monument's crates on crates.io

### DIFF
--- a/monument/cli/Cargo.toml
+++ b/monument/cli/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 authors = ["Ben White-Horne <kneasle@gmail.com>"]
 description = "CLI interface to Monument, a fast and flexible composing engine."
+readme = "../README.md"
 license = "MIT"
 repository = "https://github.com/kneasle/ringing-monorepo"
 

--- a/monument/lib/Cargo.toml
+++ b/monument/lib/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 authors = ["Ben White-Horne <kneasle@gmail.com>"]
 description = "A fast and flexible composing engine."
+readme = "../README.md"
 license = "MIT"
 repository = "https://github.com/kneasle/ringing-monorepo"
 

--- a/monument/lib/src/lib.rs
+++ b/monument/lib/src/lib.rs
@@ -1,3 +1,5 @@
+//! Core library for Monument, a fast and flexible composing engine.
+
 #![deny(clippy::all)]
 #![deny(rustdoc::broken_intra_doc_links)]
 


### PR DESCRIPTION
Both `monument` and `monument_cli` use `monument/README.md` for their crates.io entries.