### PR TITLE
Improvements to `start_indices`/`end_indices`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## (Unreleased)
 
+### Monument
+- (#48) Allow `start_indices`/`end_indices` to be overridden for each method
+- (#48) Allow negative values for `start_indices`/`end_indices` (still relative to 0 as a standard
+    start)
+
 ### BellFrame
 - (#47) Rename `AnnotBlock` to `Block` (removing the type-def `Block = AnnotBlock<()>`).
 - (#47) Use `u8` instead of `usize` as the underlying representation for `Bell`, `Stage` and places.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - (#47) Use `u8` instead of `usize` as the underlying representation for `Bell`, `Stage` and places.
 
 ### Internal Improvements
+- (#48) Make integration tests error on unspecified/new test cases
 - (#44) Rewrite the test harness, which now doesn't depend on Python and also allows error messages
     to be tested.
 - (#43) Add READMEs on Monument's pages [on crates.io](https://crates.io/crates/monument).

--- a/bellframe/src/mask.rs
+++ b/bellframe/src/mask.rs
@@ -492,6 +492,7 @@ mod tests {
         check_err_mismatched_length("xx3", 4, 3);
         check_err_mismatched_length("xxxx3x", 4, 6);
         check_err_mismatched_length("xxxx3*", 4, 5);
+        check_err_mismatched_length("3421", 8, 4);
     }
 
     #[test]

--- a/monument/cli/guide.md
+++ b/monument/cli/guide.md
@@ -232,7 +232,10 @@ method = "Bristol Surprise Major"
 title = "Lincolnshire Surprise Major"
 shorthand = "N" # (optional; defaults to the first letter of the title)
 lead_locations = { 0: "LE", 16: "HL" } # (optional; defaults to `{0:"LE"}`)
-course_heads = ["*78"] # (optional; defaults to global `course_heads`)
+# Overrides for global values (all optional):
+course_heads = ["*78"]
+start_indices = [2]
+end_indices = [2]
 
 # or
 
@@ -242,7 +245,10 @@ place_notation = "x4x36x5x8,8"
 stage = 8
 shorthand = "N" # (optional; defaults to the first letter of the title)
 lead_locations = { 0: "LE", 8: "HL" } # (optional; defaults to `{0:"LE"}`)
-course_heads = ["*78"] # (optional; defaults to global `course_heads`)
+# Overrides for global values (all optional):
+course_heads = ["*78"]
+start_indices = [2]
+end_indices = [2]
 ```
 
 #### `methods`
@@ -423,7 +429,8 @@ Defaults to `false` (i.e. just lead end starts).
 
 Sets the indices within the lead where the composition can start/end.  The default value of
 `start_indices` is determined by `snap_start`, whereas the `end_indices` defaults to allowing any
-value.
+value. These indices are taken modulo the lead length and can be negative, so for example 2, -30 and
+34 would all refer to the backstroke snap in treble dodging Major.
 
 ---
 

--- a/monument/cli/src/lib.rs
+++ b/monument/cli/src/lib.rs
@@ -130,6 +130,7 @@ pub enum Error {
     MusicFile(PathBuf, spec::TomlReadError),
 
     PartHeadParse(InvalidRowError),
+    // TODO: For too short inputs, suggest expanding with either bells or a `*`
     ChMaskParse(String, bellframe::mask::ParseError),
     ChPatternParse(String, bellframe::mask::ParseError),
 

--- a/monument/lib/src/layout/new/utils.rs
+++ b/monument/lib/src/layout/new/utils.rs
@@ -105,7 +105,7 @@ fn add_fixed_bells_to_method(method: &mut super::Method, fixed_bells: &[Bell]) {
 pub(super) fn fixed_bells(methods: &[super::Method], stage: Stage) -> Vec<Bell> {
     let mut all_bells = stage.bells().collect_vec();
     for m in methods {
-        let f = fixed_bells_of_method(&m.method, &m.calls);
+        let f = fixed_bells_of_method(&m.inner, &m.calls);
         all_bells.retain(|b| f.contains(b));
     }
     all_bells
@@ -233,8 +233,8 @@ pub(super) fn check_duplicate_shorthands(methods: &[super::Method]) -> super::Re
             if m1.shorthand == m2.shorthand {
                 return Err(Error::DuplicateShorthand {
                     shorthand: m1.shorthand.to_owned(),
-                    title1: m1.method.title().to_owned(),
-                    title2: m2.method.title().to_owned(),
+                    title1: m1.title().to_owned(),
+                    title2: m2.title().to_owned(),
                 });
             }
         }

--- a/monument/test/cases/negative-start-index-2.toml
+++ b/monument/test/cases/negative-start-index-2.toml
@@ -1,0 +1,13 @@
+length = { min = 0, max = 500 }
+method = "Birthday Delight Major"
+music_file = "music-8.toml"
+start_indices = [-4]
+end_indices = [0, 2]
+course_heads = ["24315678", "1*78"]
+
+bob_weight = -6
+single_weight = -10
+
+[[calls]]
+symbol = "t"
+place_notation = "34"

--- a/monument/test/cases/negative-start-index.toml
+++ b/monument/test/cases/negative-start-index.toml
@@ -1,0 +1,12 @@
+length = { min = 0, max = 500 }
+method = "Birthday Delight Major"
+music_file = "music-8.toml"
+start_indices = [-4]
+course_heads = ["24315678", "1*78"]
+
+bob_weight = -6
+single_weight = -10
+
+[[calls]]
+symbol = "t"
+place_notation = "34"

--- a/monument/test/cases/per-method-chs.toml
+++ b/monument/test/cases/per-method-chs.toml
@@ -1,3 +1,4 @@
+# Only allow the plain course of Bristol
 length = "practice"
 methods = [
     "Yorkshire Surprise Major",

--- a/monument/test/cases/per-method-start-ends-2.toml
+++ b/monument/test/cases/per-method-start-ends-2.toml
@@ -1,0 +1,8 @@
+length = "practice"
+methods = [
+    "Yorkshire Surprise Major",
+    { title = "Bristol Surprise Major", start_indices = [0, 2], end_indices = [0, 2] }
+]
+end_indices = [2] # Force Yorkshire to finish at the snap
+course_heads = ["*5678"] # Don't allow snaps in Bristol (because that'd require `*5x678`)
+method_count = { min = 0, max = 400 }

--- a/monument/test/cases/per-method-start-ends-3.toml
+++ b/monument/test/cases/per-method-start-ends-3.toml
@@ -1,0 +1,8 @@
+length = "practice"
+methods = [
+    "Yorkshire Surprise Major",
+    { title = "Bristol Surprise Major", start_indices = [0, 2], end_indices = [0, 2] }
+]
+end_indices = [2] # Force Yorkshire to finish at the snap
+course_heads = ["*5678", "*5x678"] # `*5x678` needed to allow snap starts/finishes in Bristol
+method_count = { min = 0, max = 400 }

--- a/monument/test/cases/per-method-start-ends.toml
+++ b/monument/test/cases/per-method-start-ends.toml
@@ -1,0 +1,8 @@
+# Only allow snap starts in Bristol
+length = "practice"
+base_calls = "none"
+methods = [
+    "Yorkshire Surprise Major",
+    { title = "Bristol Surprise Major", start_indices = [0, 2], end_indices = [0, 2] }
+]
+method_count = { min = 0, max = 400 }

--- a/monument/test/results.json
+++ b/monument/test/results.json
@@ -3923,6 +3923,134 @@
       }
     ]
   },
+  "test/cases/negative-start-index-2.toml": {
+    "comps": [
+      {
+        "length": 388,
+        "string": "<tMBsWHMsWH",
+        "avg_score": -0.06185567
+      },
+      {
+        "length": 356,
+        "string": "<tMBsMBsWH",
+        "avg_score": -0.058988765
+      },
+      {
+        "length": 356,
+        "string": "<tMBBsWsH",
+        "avg_score": -0.039325844
+      },
+      {
+        "length": 388,
+        "string": "<tMWHsMBsW",
+        "avg_score": -0.038659792
+      },
+      {
+        "length": 388,
+        "string": "<tMBWHsMsH",
+        "avg_score": -0.025773196
+      },
+      {
+        "length": 356,
+        "string": "<tMBsWBsW",
+        "avg_score": -0.025280898
+      },
+      {
+        "length": 388,
+        "string": "<tMWsHsMB",
+        "avg_score": -0.0154639175
+      },
+      {
+        "length": 388,
+        "string": "<tMBWHMH",
+        "avg_score": -0.0025773195
+      },
+      {
+        "length": 390,
+        "string": "<tMsHM>",
+        "avg_score": 0.020512821
+      },
+      {
+        "length": 356,
+        "string": "<tMBWBW",
+        "avg_score": 0.042134833
+      },
+      {
+        "length": 420,
+        "string": "<tMM",
+        "avg_score": 0.0952381
+      }
+    ]
+  },
+  "test/cases/negative-start-index.toml": {
+    "comps": [
+      {
+        "length": 388,
+        "string": "<tMBsWHMsWH",
+        "avg_score": -0.06185567
+      },
+      {
+        "length": 356,
+        "string": "<tMBsMBsWH",
+        "avg_score": -0.058988765
+      },
+      {
+        "length": 356,
+        "string": "<tMBBsWsH",
+        "avg_score": -0.039325844
+      },
+      {
+        "length": 388,
+        "string": "<tMWHsMBsW",
+        "avg_score": -0.038659792
+      },
+      {
+        "length": 388,
+        "string": "<tMBWHsMsH",
+        "avg_score": -0.025773196
+      },
+      {
+        "length": 356,
+        "string": "<tMBsWBsW",
+        "avg_score": -0.025280898
+      },
+      {
+        "length": 388,
+        "string": "<tMWsHsMB",
+        "avg_score": -0.0154639175
+      },
+      {
+        "length": 388,
+        "string": "<tMBWHMH",
+        "avg_score": -0.0025773195
+      },
+      {
+        "length": 390,
+        "string": "<tMsHM>",
+        "avg_score": 0.020512821
+      },
+      {
+        "length": 356,
+        "string": "<tMBWBW",
+        "avg_score": 0.042134833
+      },
+      {
+        "length": 448,
+        "string": "<tMtM>",
+        "avg_score": 0.07589286
+      },
+      {
+        "length": 420,
+        "string": "<tMM",
+        "avg_score": 0.0952381
+      },
+      {
+        "length": 224,
+        "string": "<>",
+        "avg_score": 0.17857143
+      }
+    ]
+  },
   "test/cases/no-87s-at-back.toml": {
     "comps": [
       {
@@ -5574,6 +5702,288 @@
         "length": 290,
         "string": "BY[W]YYYYYYY[sW]Y>",
         "avg_score": -0.014137931
+      },
+      {
+        "length": 224,
+        "string": "BBBBBBB",
+        "avg_score": 0.0
+      },
+      {
+        "length": 224,
+        "string": "YYYYYYY",
+        "avg_score": 0.0
+      }
+    ]
+  },
+  "test/cases/per-method-start-ends-2.toml": {
+    "comps": [
+      {
+        "length": 64,
+        "string": "B[sH]B[sH]",
+        "avg_score": -0.071875
+      },
+      {
+        "length": 128,
+        "string": "B[H]B[sH]B[H]B[sH]",
+        "avg_score": -0.0640625
+      },
+      {
+        "length": 128,
+        "string": "B[sH]B[H]B[sH]B[H]",
+        "avg_score": -0.0640625
+      },
+      {
+        "length": 192,
+        "string": "B[H]B[H]B[sH]B[H]B[H]B[sH]",
+        "avg_score": -0.061458334
+      },
+      {
+        "length": 192,
+        "string": "B[H]B[sH]B[H]B[H]B[sH]B[H]",
+        "avg_score": -0.061458334
+      },
+      {
+        "length": 192,
+        "string": "B[sH]B[H]B[H]B[sH]B[H]B[H]",
+        "avg_score": -0.061458334
+      },
+      {
+        "length": 96,
+        "string": "B[H]B[H]B[H]",
+        "avg_score": -0.056249995
+      },
+      {
+        "length": 194,
+        "string": "B[H]B[sH]B[H]B[H]BYY>",
+        "avg_score": -0.03969072
+      },
+      {
+        "length": 162,
+        "string": "B[H]B[H]B[sH]BYY>",
+        "avg_score": -0.03641975
+      },
+      {
+        "length": 130,
+        "string": "B[sH]B[H]BYY>",
+        "avg_score": -0.03153846
+      },
+      {
+        "length": 194,
+        "string": "B[sH]B[H]YYYYY>",
+        "avg_score": -0.02113402
+      },
+      {
+        "length": 290,
+        "string": "B[H]B[H]B[sH]BBBBBBY>",
+        "avg_score": -0.020344825
+      },
+      {
+        "length": 288,
+        "string": "B[H]B[H]YYYYYYY[H]",
+        "avg_score": -0.018749999
+      },
+      {
+        "length": 288,
+        "string": "B[H]YYYYYYY[H]B[H]",
+        "avg_score": -0.018749999
+      },
+      {
+        "length": 288,
+        "string": "YYYYYYY[H]B[H]B[H]",
+        "avg_score": -0.018749999
+      },
+      {
+        "length": 256,
+        "string": "B[sH]YYYYYYY[sH]",
+        "avg_score": -0.01796875
+      },
+      {
+        "length": 256,
+        "string": "YYYYYYY[sH]B[sH]",
+        "avg_score": -0.01796875
+      },
+      {
+        "length": 258,
+        "string": "B[sH]B[H]BBBBBBY>",
+        "avg_score": -0.015891472
+      },
+      {
+        "length": 224,
+        "string": "BBBBBBB",
+        "avg_score": 0.0
+      },
+      {
+        "length": 224,
+        "string": "YYYYYYY",
+        "avg_score": 0.0
+      }
+    ]
+  },
+  "test/cases/per-method-start-ends-3.toml": {
+    "comps": [
+      {
+        "length": 64,
+        "string": "<[sW]B[sW]B>",
+        "avg_score": -0.071875
+      },
+      {
+        "length": 64,
+        "string": "B[sH]B[sH]",
+        "avg_score": -0.071875
+      },
+      {
+        "length": 128,
+        "string": "<[W]B[sW]B[W]B[sW]B>",
+        "avg_score": -0.0640625
+      },
+      {
+        "length": 128,
+        "string": "<[sW]B[W]B[sW]B[W]B>",
+        "avg_score": -0.0640625
+      },
+      {
+        "length": 128,
+        "string": "B[H]B[sH]B[H]B[sH]",
+        "avg_score": -0.0640625
+      },
+      {
+        "length": 128,
+        "string": "B[sH]B[H]B[sH]B[H]",
+        "avg_score": -0.0640625
+      },
+      {
+        "length": 192,
+        "string": "<[W]B[W]B[sW]B[W]B[W]B[sW]B>",
+        "avg_score": -0.061458334
+      },
+      {
+        "length": 192,
+        "string": "<[W]B[sW]B[W]B[W]B[sW]B[W]B>",
+        "avg_score": -0.061458334
+      },
+      {
+        "length": 192,
+        "string": "<[sW]B[W]B[W]B[sW]B[W]B[W]B>",
+        "avg_score": -0.061458334
+      },
+      {
+        "length": 192,
+        "string": "B[H]B[H]B[sH]B[H]B[H]B[sH]",
+        "avg_score": -0.061458334
+      },
+      {
+        "length": 192,
+        "string": "B[H]B[sH]B[H]B[H]B[sH]B[H]",
+        "avg_score": -0.061458334
+      },
+      {
+        "length": 192,
+        "string": "B[sH]B[H]B[H]B[sH]B[H]B[H]",
+        "avg_score": -0.061458334
+      },
+      {
+        "length": 96,
+        "string": "<[W]B[W]B[W]B>",
+        "avg_score": -0.056249995
+      },
+      {
+        "length": 96,
+        "string": "B[H]B[H]B[H]",
+        "avg_score": -0.056249995
+      },
+      {
+        "length": 194,
+        "string": "B[H]B[sH]B[H]B[H]BYY>",
+        "avg_score": -0.03969072
+      },
+      {
+        "length": 162,
+        "string": "B[H]B[H]B[sH]BYY>",
+        "avg_score": -0.03641975
+      },
+      {
+        "length": 130,
+        "string": "B[sH]B[H]BYY>",
+        "avg_score": -0.03153846
+      },
+      {
+        "length": 194,
+        "string": "B[sH]B[H]YYYYY>",
+        "avg_score": -0.02113402
+      },
+      {
+        "length": 290,
+        "string": "B[H]B[H]B[sH]BBBBBBY>",
+        "avg_score": -0.020344825
+      },
+      {
+        "length": 288,
+        "string": "<[W]B[W]YYYYYYY[W]B>",
+        "avg_score": -0.018749999
+      },
+      {
+        "length": 288,
+        "string": "<[W]YYYYYYY[W]B[W]B>",
+        "avg_score": -0.018749999
+      },
+      {
+        "length": 288,
+        "string": "B[H]B[H]YYYYYYY[H]",
+        "avg_score": -0.018749999
+      },
+      {
+        "length": 288,
+        "string": "B[H]YYYYYYY[H]B[H]",
+        "avg_score": -0.018749999
+      },
+      {
+        "length": 288,
+        "string": "YYYYYYY[H]B[H]B[H]",
+        "avg_score": -0.018749999
+      },
+      {
+        "length": 256,
+        "string": "<[sW]YYYYYYY[sW]B>",
+        "avg_score": -0.01796875
+      },
+      {
+        "length": 256,
+        "string": "B[sH]YYYYYYY[sH]",
+        "avg_score": -0.01796875
+      },
+      {
+        "length": 256,
+        "string": "YYYYYYY[sH]B[sH]",
+        "avg_score": -0.01796875
+      },
+      {
+        "length": 258,
+        "string": "B[sH]B[H]BBBBBBY>",
+        "avg_score": -0.015891472
+      },
+      {
+        "length": 224,
+        "string": "<BBBBBBB>",
+        "avg_score": 0.0
+      },
+      {
+        "length": 224,
+        "string": "BBBBBBB",
+        "avg_score": 0.0
+      },
+      {
+        "length": 224,
+        "string": "YYYYYYY",
+        "avg_score": 0.0
+      }
+    ]
+  },
+  "test/cases/per-method-start-ends.toml": {
+    "comps": [
+      {
+        "length": 224,
+        "string": "<BBBBBBB>",
+        "avg_score": 0.0
       },
       {
         "length": 224,

--- a/monument/test/src/common.rs
+++ b/monument/test/src/common.rs
@@ -538,7 +538,7 @@ fn print_summary_string(completed_tests: &[RunTestCase]) -> Outcome {
         completed_tests.len()
     ); // All tests should be counted in some way
 
-    let outcome = if num_failures == 0 {
+    let outcome = if num_failures == 0 && num_unspecified == 0 {
         Outcome::Pass
     } else {
         Outcome::Fail


### PR DESCRIPTION
- `start_indices`/`end_indices` can be overridden for a single method
- `start_indices`/`end_indices` now accept negative numbers, interpreted as 'rows before the lead end'