### PR TITLE
Print comp list even if the user aborts with `ctrl-C`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## (Unreleased)
 
 ### Monument
+- (#54) Don't bother freeing memory allocated during the search algorithm.  This makes Monument
+    terminate instantly, often shaving 10s of seconds from the search time.
 - (#53) Add limit on graph size.  Set with `--graph-size-limit`, defaults to 100K chunks.
 - (#50) Add `bobs_only` and `singles_only`.
 - (#50) Fix some dead links in Monument's guide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## (Unreleased)
 
 ### Monument
+- (#54) Print comp list even when a search is aborted with `ctrl-C`.
 - (#54) Don't bother freeing memory allocated during the search algorithm.  This makes Monument
     terminate instantly, often shaving 10s of seconds from the search time.
 - (#53) Add limit on graph size.  Set with `--graph-size-limit`, defaults to 100K chunks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +648,7 @@ dependencies = [
  "anyhow",
  "bellframe",
  "colored",
+ "ctrlc",
  "difference",
  "itertools",
  "kneasle_ringing_utils",
@@ -669,6 +680,19 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/monument/cli/Cargo.toml
+++ b/monument/cli/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/kneasle/ringing-monorepo"
 
 [dependencies]
 bellframe = { version = "0.8.0", path = "../../bellframe/", features = ["serde"] }
+ctrlc = "3.2"
 itertools = "0.10"
 log = "0.4"
 monument = { version = "0.5.0", path = "../lib/" }

--- a/monument/cli/src/main.rs
+++ b/monument/cli/src/main.rs
@@ -5,14 +5,19 @@ use std::path::PathBuf;
 
 use log::LevelFilter;
 use monument::Config;
-use monument_cli::DebugOption;
+use monument_cli::{CtrlCBehaviour, DebugOption};
 use structopt::StructOpt;
 
 fn main() {
     let args = CliArgs::from_args();
     monument_cli::init_logging(args.log_level());
-    let maybe_results =
-        monument_cli::run(&args.input_file, args.debug_option, &args.config()).unwrap();
+    let maybe_results = monument_cli::run(
+        &args.input_file,
+        args.debug_option,
+        &args.config(),
+        CtrlCBehaviour::RecoverComps,
+    )
+    .unwrap();
     if let Some(results) = maybe_results {
         results.print();
     }

--- a/monument/cli/src/main.rs
+++ b/monument/cli/src/main.rs
@@ -69,6 +69,10 @@ impl CliArgs {
     fn config(&self) -> Config {
         let mut config = Config {
             num_threads: self.num_threads,
+            // Don't `drop` any of the search data structures, since Monument will exit shortly
+            // after the search terminates.  With the `Arc`-based data structures, this is
+            // seriously beneficial - it shaves many seconds off Monument's total running time.
+            mem_forget_search_data: true,
             ..Config::default()
         };
         if let Some(q) = self.queue_limit {

--- a/monument/lib/src/lib.rs
+++ b/monument/lib/src/lib.rs
@@ -301,6 +301,8 @@ pub enum QueryUpdate {
     Progress(Progress),
     /// The queue of prefixes has got too large and is being shortened
     TruncatingQueue,
+    /// The search is being aborted
+    Aborting,
 }
 
 #[derive(Debug)]

--- a/monument/lib/src/search/mod.rs
+++ b/monument/lib/src/search/mod.rs
@@ -178,7 +178,7 @@ pub(crate) fn search(
         if iter_count % ITERS_BETWEEN_ABORT_CHECKS == 0
             && abort_flag.load(std::sync::atomic::Ordering::Relaxed)
         {
-            log::info!("Aborting");
+            update_channel.send(QueryUpdate::Aborting).unwrap();
             break;
         }
 

--- a/monument/lib/src/search/mod.rs
+++ b/monument/lib/src/search/mod.rs
@@ -28,6 +28,7 @@ pub(crate) fn search(
     graph: &crate::Graph,
     query: Arc<Query>,
     queue_limit: usize,
+    mem_forget_search_data: bool,
     update_channel: SyncSender<QueryUpdate>,
     abort_flag: Arc<AtomicBool>,
 ) {
@@ -178,7 +179,7 @@ pub(crate) fn search(
             && abort_flag.load(std::sync::atomic::Ordering::Relaxed)
         {
             log::info!("Aborting");
-            return;
+            break;
         }
 
         // Send stats every so often
@@ -199,6 +200,14 @@ pub(crate) fn search(
                 }))
                 .unwrap();
         }
+    }
+
+    // If we're running the CLI, then `mem::forget` the frontier to avoid tons of drop calls.  We
+    // don't care about leaking because the Monument process is about to terminate and the OS will
+    // clean up the memory anyway.
+    if mem_forget_search_data {
+        std::mem::forget(graph);
+        std::mem::forget(frontier);
     }
 }
 

--- a/monument/test/src/common.rs
+++ b/monument/test/src/common.rs
@@ -12,7 +12,7 @@ use colored::{Color, ColoredString, Colorize};
 use difference::Changeset;
 use itertools::Itertools;
 use monument::Config;
-use monument_cli::DebugOption;
+use monument_cli::{CtrlCBehaviour, DebugOption};
 use ordered_float::OrderedFloat;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
@@ -407,6 +407,7 @@ fn run_test(case: UnrunTestCase, config: &Config) -> RunTestCase {
         &file_path_from_cargo_toml,
         no_search.then(|| DebugOption::StopBeforeSearch),
         config,
+        CtrlCBehaviour::TerminateProcess, // Don't bother recovering comps whilst testing
     );
     // Convert Monument's `Result` into a `Results`
     let actual_results = match monument_result {


### PR DESCRIPTION
This also `std::mem::forget`s all of the search data structures so that the abort signal actually takes effect quickly.  This also has a substantial effect on search speed, since it often takes several seconds to drop the massive `Arc` tree that stores the prefixes.