### PR TITLE
Make `./to-complib.py` handle 2-letter shorthands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## (Unreleased)
 
 ### Monument
+- (#56) Allow `to-complib.py` to handle multiple-letter method shorthands.
 - (#55) Print warning for using plain-bob style calls in Grandsire or Stedman.
 - (#54) Print comp list even when a search is aborted with `ctrl-C`.
 - (#54) Don't bother freeing memory allocated during the search algorithm.  This makes Monument

--- a/monument/to-complib.py
+++ b/monument/to-complib.py
@@ -29,7 +29,9 @@ def convert_leadwise(callstring):
     call_indices = []
     call_symbols = []
     def add_call(symbol):
-        call_indices.append(str(len(method_string)))
+        # assuming that number of leads = number of capital letters
+        lead_index = len([c for c in method_string if c.isupper()])
+        call_indices.append(str(lead_index))
         call_symbols.append(symbol)
 
     is_method = True


### PR DESCRIPTION
Previously, leadwise comps (i.e. using positional notation) would assume that each method corresponded to a single character, and therefore would get the call positions wrong if 2-letter shorthands were used.  Now, each lead is assumed to correspond to one uppercase char, followed by any number of non-uppercase chars.