### PR TITLE
Fix guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## (Unreleased)
 
 ### Monument
+- (#57) Fix mistake in `guide.md` which turned a large part of the guide into a giant code block.
 - (#56) Allow `to-complib.py` to handle multiple-letter method shorthands.
 - (#55) Print warning for using plain-bob style calls in Grandsire or Stedman.
 - (#54) Print comp list even when a search is aborted with `ctrl-C`.

--- a/monument/cli/guide.md
+++ b/monument/cli/guide.md
@@ -403,7 +403,7 @@ weight = 0.05 # this is small because the weight is applied per row
 Generates `ch_weights` which apply the given weight to every row where a handbell pair coursing
 (this score gets multiplied for courses with multiple handbell pairs coursing).  Equivalent to
 something like this (truncated according to stage):
-```toml`
+```toml
 [[ch_weights]]
 patterns = [
     "*12", "*21",


### PR DESCRIPTION
Remove misplaced backtick, which cased a large section of the guide to turn into a code block.