### PR TITLE
Better error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Monument
 - (#58) Allow `calling_positions = "<string>"` to set the calling positions of a call to the
     characters in `<string>`.
+- (#58) Allow multiple test cases to be stored in one file
 - (#58) Add nice error messages for all custom errors (serde's errors are still lacking, but there's
     little I can do about them for now).
 - (#57) Fix mistake in `guide.md` which turned a large part of the guide into a giant code block.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## (Unreleased)
 
 ### Monument
+- (#58) Allow `calling_positions = "<string>"` to set the calling positions of a call to the
+    characters in `<string>`.
 - (#58) Add nice error messages for all custom errors (serde's errors are still lacking, but there's
     little I can do about them for now).
 - (#57) Fix mistake in `guide.md` which turned a large part of the guide into a giant code block.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## (Unreleased)
 
 ### Monument
+- (#58) Add nice error messages for all custom errors (serde's errors are still lacking, but there's
+    little I can do about them for now).
 - (#57) Fix mistake in `guide.md` which turned a large part of the guide into a giant code block.
 - (#56) Allow `to-complib.py` to handle multiple-letter method shorthands.
 - (#55) Print warning for using plain-bob style calls in Grandsire or Stedman.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - (#50) Add `bobs_only` and `singles_only`.
 - (#50) Fix some dead links in Monument's guide.
 
+### BellFrame
+- (#58) Fix incorrect indices for `PnBlockParseError`
+
 ---
 
 ## 18th Feb 2021

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,7 @@ dependencies = [
  "ordered-float",
  "pulldown-cmark",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
  "simple_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +664,7 @@ dependencies = [
  "log",
  "monument",
  "ordered-float",
+ "pulldown-cmark",
  "rayon",
  "serde",
  "serde_json",
@@ -845,6 +855,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f197a544b0c9ab3ae46c359a7ec9cbbb5c7bf97054266fecb7ead794a181d6"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -1340,6 +1362,15 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/bellframe/src/mask.rs
+++ b/bellframe/src/mask.rs
@@ -35,7 +35,7 @@ impl Mask {
         // TODO: Check validity
     }
 
-    pub fn parse_with_stage(s: &str, stage: Stage) -> Result<Self, RegexToMaskError> {
+    pub fn parse_with_stage(s: &str, stage: Stage) -> Result<Self, ParseError> {
         Self::from_regex(&Regex::parse(s), stage)
     }
 

--- a/bellframe/src/row/errors.rs
+++ b/bellframe/src/row/errors.rs
@@ -35,15 +35,15 @@ impl Display for InvalidRowError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             InvalidRowError::DuplicateBell(bell) => {
-                write!(f, "Bell '{}' appears twice.", bell)
+                write!(f, "bell '{}' appears twice.", bell)
             }
             InvalidRowError::BellOutOfStage(bell, stage) => {
-                write!(f, "Bell '{}' is not within stage {}", bell, stage)
+                write!(f, "bell '{}' is not within stage {}", bell, stage)
             }
             InvalidRowError::MissingBell(bell) => {
-                write!(f, "Bell '{}' is missing", bell)
+                write!(f, "bell '{}' is missing", bell)
             }
-            InvalidRowError::NoBells => write!(f, "Row would have no bells"),
+            InvalidRowError::NoBells => write!(f, "row would have no bells"),
         }
     }
 }

--- a/monument/cli/Cargo.toml
+++ b/monument/cli/Cargo.toml
@@ -10,8 +10,11 @@ license = "MIT"
 repository = "https://github.com/kneasle/ringing-monorepo"
 
 [dependencies]
+anyhow = "1.0"
 bellframe = { version = "0.8.0", path = "../../bellframe/", features = ["serde"] }
+colored = "2.0"
 ctrlc = "3.2"
+difference = "2.0"
 itertools = "0.10"
 log = "0.4"
 monument = { version = "0.5.0", path = "../lib/" }
@@ -23,9 +26,6 @@ structopt = "0.3"
 toml = "0.5"
 
 [dev-dependencies]
-anyhow = "1.0"
-colored = "2.0"
-difference = "2.0"
 serde_json = "1.0"
 ordered-float = { version = "2.10", features = ["serde"] }
 rayon = "1.5"

--- a/monument/cli/Cargo.toml
+++ b/monument/cli/Cargo.toml
@@ -29,6 +29,7 @@ toml = "0.5"
 ordered-float = { version = "2.10", features = ["serde"] }
 pulldown-cmark = "0.9"
 rayon = "1.5"
+regex = "1.5"
 serde_json = "1.0"
 walkdir = "2.3"
 

--- a/monument/cli/Cargo.toml
+++ b/monument/cli/Cargo.toml
@@ -26,9 +26,10 @@ structopt = "0.3"
 toml = "0.5"
 
 [dev-dependencies]
-serde_json = "1.0"
 ordered-float = { version = "2.10", features = ["serde"] }
+pulldown-cmark = "0.9"
 rayon = "1.5"
+serde_json = "1.0"
 walkdir = "2.3"
 
 [[test]]

--- a/monument/cli/src/main.rs
+++ b/monument/cli/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
     let args = CliArgs::from_args();
     monument_cli::init_logging(args.log_level());
     let result = monument_cli::run(
-        &args.input_file,
+        monument_cli::Source::Path(&args.input_file),
         args.debug_option,
         &args.config(),
         CtrlCBehaviour::RecoverComps,

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     ops::{Deref, Range},
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use bellframe::{
@@ -480,6 +481,8 @@ impl MethodSpec {
                     );
                     log::warn!("In general, Grandsire and Stedman aren't very well supported yet.");
                     log::warn!("You're welcome to try, but be wary that weird things may happen.");
+                    // Pause so that the user can register the warnings
+                    std::thread::sleep(Duration::from_secs_f32(2.0));
                 }
                 _ => {}
             }

--- a/monument/lib/src/graph/mod.rs
+++ b/monument/lib/src/graph/mod.rs
@@ -399,8 +399,8 @@ impl Chunk {
 /// The different ways that graph building can fail
 #[derive(Debug)]
 pub enum BuildError {
-    /// The maximum graph size limit was reached
-    SizeLimit,
+    /// The given maximum graph size limit was reached
+    SizeLimit(usize),
 }
 
 impl Graph {
@@ -646,7 +646,7 @@ fn build_graph(query: &Query, size_limit: usize) -> Result<BuiltGraph, BuildErro
         // Mark this chunk as expanded
         expanded_chunk_ranges.insert(chunk_id, (chunk_range, distance));
         if expanded_chunk_ranges.len() > size_limit {
-            return Err(BuildError::SizeLimit);
+            return Err(BuildError::SizeLimit(size_limit));
         }
     }
 

--- a/monument/lib/src/layout/new/coursewise.rs
+++ b/monument/lib/src/layout/new/coursewise.rs
@@ -250,7 +250,10 @@ fn generate_call_links(
         let call_starts = link_gen_data
             .call_starts_by_label
             .get(lead_label)
-            .ok_or_else(|| Error::UndefinedLeadLocation(lead_label.to_owned()))?;
+            .ok_or_else(|| Error::UndefinedLeadLocation {
+                call_name: call.debug_symbol.to_owned(),
+                label: lead_label.to_owned(),
+            })?;
         for &from_idx in call_starts {
             if from_idx.block.index() != method_idx {
                 continue; // Skip any call starts which aren't from this method

--- a/monument/lib/src/layout/new/mod.rs
+++ b/monument/lib/src/layout/new/mod.rs
@@ -1,5 +1,7 @@
 //! Utility code for building [`Layout`]s in common scenarios.
 
+use std::fmt::{Display, Formatter};
+
 use bellframe::{method::RowAnnot, Bell, Block, Mask, PlaceNot, Row, Stage};
 use itertools::Itertools;
 use serde::Deserialize;
@@ -38,7 +40,10 @@ impl Layout {
 #[derive(Debug, Clone)]
 pub enum Error {
     NoMethods,
-    UndefinedLeadLocation(String),
+    UndefinedLeadLocation {
+        call_name: String,
+        label: String,
+    },
     DuplicateShorthand {
         shorthand: String,
         title1: String,
@@ -62,6 +67,62 @@ pub enum Error {
         input_mask2: Mask,
     },
 }
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoMethods => write!(f, "Can't have a composition with no methods"),
+            Self::DuplicateShorthand {
+                shorthand,
+                title1,
+                title2,
+            } => write!(
+                f,
+                "Methods {:?} and {:?} share a shorthand ({})",
+                title1, title2, shorthand
+            ),
+            Self::UndefinedLeadLocation { call_name, label } => write!(
+                f,
+                "Call {:?} refers to a lead location {:?}, which doesn't exist",
+                call_name, label
+            ), // TODO: Suggest one that does exist
+            Self::CallingPositionsTooShort {
+                call_name,
+                calling_position_len,
+                stage,
+            } => {
+                write!(
+                    f,
+                    "Call {:?} only specifies {} calling positions, but the stage is {}",
+                    call_name, calling_position_len, stage
+                )
+            }
+            // TODO: Rename 'calling bells' to 'observation bell'
+            Self::ConflictingCallingBell((mask1, calling_bell1), (mask2, calling_bell2)) => {
+                write!(
+                    f,
+                    "Conflicting observation bells:\n      {} wants {}\n  but {} wants {}",
+                    mask1, calling_bell1, mask2, calling_bell2
+                )
+            } // TODO: Make a test case for this once custom calling bells are possible
+            Self::AmbiguousCourseHeadPosition {
+                mask1,
+                input_mask1,
+                mask2,
+                input_mask2,
+            } => {
+                write!(
+                    f,
+                    "The same course could be given two different course heads:"
+                )?;
+                write!(f, "\n     {}, satisfying {}", mask1, input_mask1)?;
+                write!(f, "\n  or {}, satisfying {}", mask2, input_mask2)
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/monument/lib/src/layout/new/mod.rs
+++ b/monument/lib/src/layout/new/mod.rs
@@ -287,40 +287,17 @@ impl From<RowAnnot<'_>> for Annot {
 /// The specification for a call that can be used in a composition
 #[derive(Debug, Clone)]
 pub struct Call {
-    display_symbol: String,
-    debug_symbol: String,
-    calling_positions: Vec<String>,
+    pub display_symbol: String,
+    pub debug_symbol: String,
+    pub calling_positions: Vec<String>,
 
-    lead_location: String,
-    place_not: PlaceNot,
+    pub lead_location: String,
+    pub place_not: PlaceNot,
 
-    weight: f32,
+    pub weight: f32,
 }
 
 impl Call {
-    pub fn new(
-        display_symbol: String,
-        debug_symbol: String,
-        calling_positions: Option<Vec<String>>,
-        lead_location: String,
-        place_not: PlaceNot,
-        weight: f32,
-    ) -> Self {
-        Self {
-            display_symbol,
-            debug_symbol,
-            calling_positions: calling_positions
-                .unwrap_or_else(|| default_calling_positions(&place_not)),
-            lead_location,
-            place_not,
-            weight,
-        }
-    }
-
-    pub fn set_weight(&mut self, weight: f32) {
-        self.weight = weight;
-    }
-
     ////////////////////////
     // DEFAULT CALL TYPES //
     ////////////////////////
@@ -354,31 +331,31 @@ impl Call {
 
     /// Create a bob which replaces the lead end with a given [`PlaceNot`]
     pub fn lead_end_bob(place_not: PlaceNot) -> Self {
-        Self::new(
-            String::new(),
-            "-".to_owned(),
-            None,
-            bellframe::method::LABEL_LEAD_END.to_owned(),
+        Self {
+            display_symbol: String::new(),
+            debug_symbol: "-".to_owned(),
+            calling_positions: default_calling_positions(&place_not),
+            lead_location: bellframe::method::LABEL_LEAD_END.to_owned(),
             place_not,
-            -1.8, // Slightly punish bobs
-        )
+            weight: -1.8, // Slightly punish bobs
+        }
     }
 
     /// Create a bob which replaces the lead end with a given [`PlaceNot`]
     pub fn lead_end_single(place_not: PlaceNot) -> Self {
-        Self::new(
-            "s".to_owned(),
-            "s".to_owned(),
-            None,
-            bellframe::method::LABEL_LEAD_END.to_owned(),
+        Self {
+            display_symbol: "s".to_owned(),
+            debug_symbol: "s".to_owned(),
+            calling_positions: default_calling_positions(&place_not),
+            lead_location: bellframe::method::LABEL_LEAD_END.to_owned(),
             place_not,
-            -2.3, // Punish singles slightly more than bobs
-        )
+            weight: -2.3, // Punish singles slightly more than bobs
+        }
     }
 }
 
 #[allow(clippy::branches_sharing_code)]
-fn default_calling_positions(place_not: &PlaceNot) -> Vec<String> {
+pub fn default_calling_positions(place_not: &PlaceNot) -> Vec<String> {
     let named_positions = "LIBFVXSEN"; // TODO: Does anyone know any more than this?
 
     // Generate calling positions that aren't M, W or H

--- a/monument/test/error-messages.md
+++ b/monument/test/error-messages.md
@@ -1,0 +1,250 @@
+# Error Message Test Suite
+
+Each section in this file corresponds to one test case and must include:
+- A sequence of nested headers, which set the name of the test (e.g. `## method-pn-parsing` and
+  `### repeated-place` will be named `method-pn-parsing/repeated-place`)
+- A fenced code region with type `toml` (this is the input file).  Optionally may include a second
+  `toml` region, which is interpreted as a music file.
+- A fenced plain-text region with no type (i.e. type `text`).  This contains the expected output
+  with any ANSI escape sequences removed.
+
+Using a markdown file allows us to conveniently embed many small files in one larger file, whilst
+still allowing syntax highlighting to work correctly.  Markdown can still be parsed easily and
+quickly whilst still being widely-used, flexible and human-readable.
+
+
+
+## method-pn-parsing
+
+### repeated-place
+```toml
+length = "QP"
+[method]
+name = "Bristol"
+place_notation = "&x5x4.5x5.36.4x4.585x4x1,+9" # 5 is repeated twice in `585`
+stage = 8
+```
+
+### misplaced-plus
+```toml
+length = "QP"
+[method]
+name = "Bristol"
+place_notation = "&x5+4.5x5.36.4x4.5x4x1,+8" # first + shouldn't be there
+stage = 8
+```
+
+### ambiguous-gap
+```toml
+length = "QP"
+[method]
+name = "Bristol"
+place_notation = "&x15x4.5x5.36.4x4.5x4x1,+8" # `15` has an ambiguous gap
+stage = 8
+```
+
+### odd-stage-cross
+```toml
+length = "QP"
+[method]
+name = "Bristol"
+place_notation = "&x15x4.5x5.36.4x4.5x4x1,+8" # Can't use 'x' in an odd stage
+stage = 7
+```
+
+### bell-out-of-stage
+```toml
+length = "QP"
+[method]
+name = "Bristol"
+place_notation = "&x5x4.5x5.36.4x4.5x4x1,+9" # 9 is too big
+stage = 8
+```
+
+
+
+## method-not-found
+
+### case-1
+```toml
+length = "QP"
+method = "Brisol Suprise Major"
+```
+
+### case-2
+```toml
+length = "QP"
+method = "Camibridge Surprise Manor"
+```
+
+### case-3
+```toml
+length = "QP"
+method = "Corwnall Surprise major" # TODO: Maybe we shouldn't display a diff for the lowercase 'm'
+```
+
+
+
+## misc-method-parsing
+
+### non-integer-lead-index
+```toml
+length = "QP"
+[method]
+title = "Bristol Surprise Royal"
+lead_locations = { X = "LE" } # 'X' isn't a valid integer
+```
+
+
+
+## no-methods
+```toml
+length = "QP"
+```
+
+
+
+## part-head-parse
+
+### 1
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+part_head = "13" # 2 is missing
+```
+
+### 2
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+part_head = "1321" # 1 is duplicated
+```
+
+### 3
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+part_head = "123456789" # 9 is out of stage Major
+```
+
+
+
+## duplicate-shorthand
+```toml
+length = "QP"
+methods = ["Lessness Surprise Major", "London Surprise Major"] # Both would be named 'L'
+```
+
+## undefined-lead-location
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+[[calls]]
+symbol = "x"
+place_notation = "16"
+lead_location = "poo" # poo isn't defined anywhere
+```
+
+## ambiguous-course-heads
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+course_heads = ["*56", "*78"]
+```
+
+## calling-positions-too-short
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+[[calls]]
+symbol = "x"
+place_notation = "16"
+calling_positions = "LIOFVMW" # No 'H'
+```
+
+## bobs-and-singles-only
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+bobs_only = true
+singles_only = true
+```
+
+## call-pn-parse
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+[[calls]]
+symbol = "x"
+place_notation = "10" # ERROR!
+```
+
+## ch-mask
+
+### too-short
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+course_heads = ["*78", "12345"]
+```
+
+### too-long
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+course_heads = ["*78", "1234x5678"]
+```
+
+### bell-out-of-stage
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+course_heads = ["*78", "1234*9"]
+```
+
+### too-many-*s
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+course_heads = ["*78", "1*2*3"]
+```
+
+
+
+## ch-pattern
+
+### too-short
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+[[ch_weights]]
+pattern = "12345"
+weight = 0.1
+```
+
+### too-long
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+[[ch_weights]]
+pattern = "1234*5678x"
+weight = 0.1
+```
+
+### bell-out-of-stage
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+[[ch_weights]]
+pattern = "x9*"
+weight = 0.1
+```
+
+### too-many-*s
+```toml
+length = "QP"
+method = "Bristol Surprise Major"
+[[ch_weights]]
+pattern = "*7*8"
+weight = 0.1
+```

--- a/monument/test/results.json
+++ b/monument/test/results.json
@@ -6200,5 +6200,86 @@
         "avg_score": 0.0
       }
     ]
+  },
+  "test/error-messages.md: ambiguous-course-heads": {
+    "error_message": "The same course could be given two different course heads:\n     1x5x6x78, satisfying 1xxxxx78\n  or 1xx8x756, satisfying 1xxxxx56"
+  },
+  "test/error-messages.md: bobs-and-singles-only": {
+    "error_message": "Can't be both `bobs_only` and `singles_only`"
+  },
+  "test/error-messages.md: call-pn-parse": {
+    "error_message": "Can't parse place notation \"10\" for call \"x\": Place '0' is out of stage Major"
+  },
+  "test/error-messages.md: calling-positions-too-short": {
+    "error_message": "Call \"x\" only specifies 7 calling positions, but the stage is Major"
+  },
+  "test/error-messages.md: ch-mask::bell-out-of-stage": {
+    "error_message": "Can't parse course head mask \"1234*9\": bell 9 is out of stage Major"
+  },
+  "test/error-messages.md: ch-mask::too-long": {
+    "error_message": "Can't parse course head mask \"1234x5678\": mask is too long, needing at least 9 bells (too many for Major)"
+  },
+  "test/error-messages.md: ch-mask::too-many-*s": {
+    "error_message": "Can't parse course head mask \"1*2*3\": too many `*`s.  Masks can only have one region with `x` or `*`."
+  },
+  "test/error-messages.md: ch-mask::too-short": {
+    "error_message": "Can't parse course head mask \"12345\": mask is too short; did you mean `12345*` or `12345678`?"
+  },
+  "test/error-messages.md: ch-pattern::bell-out-of-stage": {
+    "error_message": "Can't parse course head weight \"x9*\": bell 9 is out of stage Major"
+  },
+  "test/error-messages.md: ch-pattern::too-long": {
+    "error_message": "Can't parse course head weight \"1234*5678x\": mask is too long, needing at least 9 bells (too many for Major)"
+  },
+  "test/error-messages.md: ch-pattern::too-many-*s": {
+    "error_message": "Can't parse course head weight \"*7*8\": too many `*`s.  Masks can only have one region with `x` or `*`."
+  },
+  "test/error-messages.md: ch-pattern::too-short": {
+    "error_message": "Can't parse course head weight \"12345\": mask is too short; did you mean `12345*` or `12345678`?"
+  },
+  "test/error-messages.md: duplicate-shorthand": {
+    "error_message": "Methods \"London Surprise Major\" and \"Lessness Surprise Major\" share a shorthand (L)"
+  },
+  "test/error-messages.md: method-not-found::case-1": {
+    "error_message": "Can't find \"Brisol Suprise Major\" in the Central Council method library.  Did you mean:\n     \"Bristol Surprise Major\" (Bristol Surprise Major)"
+  },
+  "test/error-messages.md: method-not-found::case-2": {
+    "error_message": "Can't find \"Camibridge Surprise Manor\" in the Central Council method library.  Did you mean:\n     \"Cambridge Surprise Major\" (Camibridge Surprise Manjor)\n  or \"Cambridge Surprise Minor\" (Camibridge Surprise Mainor)"
+  },
+  "test/error-messages.md: method-not-found::case-3": {
+    "error_message": "Can't find \"Corwnall Surprise major\" in the Central Council method library.  Did you mean:\n     \"Cornwall Surprise Major\" (Cornwnall Surprise mMajor)"
+  },
+  "test/error-messages.md: method-pn-parsing::ambiguous-gap": {
+    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x15x4.5x5.36.4x4.5x4x1,+8\"\n        ^^ Ambiguous gap of 3 bells between places '1' and '5'."
+  },
+  "test/error-messages.md: method-pn-parsing::bell-out-of-stage": {
+    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x5x4.5x5.36.4x4.5x4x1,+9\"\n                              ^ Place '9' is out of stage Major"
+  },
+  "test/error-messages.md: method-pn-parsing::misplaced-plus": {
+    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x5+4.5x5.36.4x4.5x4x1,+8\"\n         ^ `+` must only go at the start of a block (i.e. at the start or directly after a `,`)"
+  },
+  "test/error-messages.md: method-pn-parsing::odd-stage-cross": {
+    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x15x4.5x5.36.4x4.5x4x1,+8\"\n       ^ Cross notation isn't valid for odd stages (in this case Triples)"
+  },
+  "test/error-messages.md: method-pn-parsing::repeated-place": {
+    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x5x4.5x5.36.4x4.585x4x1,+9\"\n                       ^^^ Place '5' is duplicated"
+  },
+  "test/error-messages.md: misc-method-parsing::non-integer-lead-index": {
+    "error_message": "Lead location \"X\" (for label \"LE\" in \"Bristol Surprise Royal\") is not a valid integer"
+  },
+  "test/error-messages.md: no-methods": {
+    "error_message": "No methods specified.  Try e.g. `method = \"Bristol Surprise Major\"`."
+  },
+  "test/error-messages.md: part-head-parse::1": {
+    "error_message": "Can't parse part head \"13\": bell '2' is missing"
+  },
+  "test/error-messages.md: part-head-parse::2": {
+    "error_message": "Can't parse part head \"1321\": bell '1' appears twice."
+  },
+  "test/error-messages.md: part-head-parse::3": {
+    "error_message": "Can't parse part head \"123456789\": bell '9' is not within stage Major"
+  },
+  "test/error-messages.md: undefined-lead-location": {
+    "error_message": "Call \"x\" refers to a lead location \"poo\", which doesn't exist"
   }
 }


### PR DESCRIPTION
Adds better messages for all messages I have control over:
- PN parsing (methods and calls)
- Row/mask parsing (part head, CH masks, CH patterns)
- Suggested methods, including diffs to show how you mistyped
- Invalid lead locations
- All `Layout` generation errors
- Reading & parsing TOML files

Also adds a few new features:
- Multiple test cases can be stored in a single file, as `toml` code blocks embedded in markdown
- Monument now recognises `calling_positions = "<string>"`, naming a calling position after each `char` in `<string>`