### PR TITLE
Require that optimisation minimise graph size

### DIFF
--- a/monument/test/cases/bobs-and-singles-only.toml
+++ b/monument/test/cases/bobs-and-singles-only.toml
@@ -1,4 +1,0 @@
-length = "practice"
-method = "Plain Bob Major"
-bobs_only = true
-singles_only = true

--- a/monument/test/ignore.toml
+++ b/monument/test/ignore.toml
@@ -3,7 +3,6 @@
 
 ignore = [
     "test/cases/no-duffers.toml",  # Duffer-based filtering is currently bugged
-    "test/cases/bobs-and-singles-only.toml", # Waiting on tests for error messages
 ]
 music_files = [
     "examples/music-6.toml",

--- a/monument/test/src/common.rs
+++ b/monument/test/src/common.rs
@@ -49,6 +49,8 @@ const QUEUE_LIMIT: usize = 10_000_000;
 
 /// Run the full test suite.
 pub fn run(run_type: RunType) -> anyhow::Result<Outcome> {
+    monument_cli::init_logging(log::LevelFilter::Warn); // Equivalent to '-q'
+
     // Collect the test cases
     let cases = sources_to_cases(collect_sources(run_type)?)?;
     // Run the tests.  We run _tests_ in parallel, but _benchmarks_ sequentially


### PR DESCRIPTION
Here, 'size' means minimising `(num chunks, num links, Reverse(num required chunks))`.  The reasoning is that smaller graphs always make tree search faster because less computation is required.