### PR TITLE
Add way to specify a single count range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## (Unreleased)
 
+### Monument
+- (#71) Allow specifying an exact count with e.g. `count = 224` rather than
+    `count = { min = 224, max = 224 }`.
+
 ---
 
 ## 28th March 2021

--- a/monument/test/cases/exact-count.toml
+++ b/monument/test/cases/exact-count.toml
@@ -1,0 +1,4 @@
+length = 224
+method = "Bristol Surprise Major"
+music_file = "music-8.toml"
+method_count = 224

--- a/monument/test/results.json
+++ b/monument/test/results.json
@@ -274,6 +274,9 @@
       { "length": 1344, "string": "#DLSYSL", "avg_score": 0.14434524, "part_head": "18234567" }
     ]
   },
+  "test/cases/exact-count.toml": {
+    "comps": [{ "length": 224, "string": "", "avg_score": 0.25892857 }]
+  },
   "test/cases/false-course-1.toml": { "comps": [] },
   "test/cases/false-course-2.toml": {
     "comps": [


### PR DESCRIPTION
Now, `count = { min = X, max = X }` can be shortened to just `count = X`