### PR TITLE
Fix splicing bugs related to multi-parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## (Unreleased)
 
 ### Monument
+- (#73) `splice_style = "calls"` will no longer generate splices over part heads.
 - (#73) `splice_weight` is now applied to splices over part heads.
 - (#73) `splice_style = "calls"` now works for cyclic compositions.
 - (#71) Allow specifying an exact count with e.g. `count = 224` rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## (Unreleased)
 
 ### Monument
+- (#73) `splice_style = "calls"` and `splice_style = "call_locations"` now work with multi-part
+    compositions which involve the tenor.
 - (#71) Allow specifying an exact count with e.g. `count = 224` rather than
     `count = { min = 224, max = 224 }`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## (Unreleased)
 
 ### Monument
-- (#73) `splice_style = "calls"` and `splice_style = "call_locations"` now work with multi-part
-    compositions which involve the tenor.
+- (#73) `splice_weight` is now applied to splices over part heads.
+- (#73) `splice_style = "calls"` now works for cyclic compositions.
 - (#71) Allow specifying an exact count with e.g. `count = 224` rather than
     `count = { min = 224, max = 224 }`.
 

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -19,11 +19,11 @@ use itertools::Itertools;
 use monument::{
     layout::{
         self,
-        new::{Call, CourseHeadMaskPreset, SpliceStyle},
+        new::{Call, CourseHeadMaskPreset},
         Layout,
     },
     music::{MusicType, StrokeSet},
-    CallType, CallVec, OptRange, Query,
+    CallType, CallVec, OptRange, Query, SpliceStyle,
 };
 use serde::Deserialize;
 
@@ -246,6 +246,7 @@ impl Spec {
             len_range: self.length.range.clone(),
             num_comps: self.num_comps,
             allow_false: self.allow_false,
+            splice_style: self.splice_style,
 
             calls: calls.into_iter().map(CallType::from).collect(),
             part_head,

--- a/monument/lib/src/layout/new/coursewise.rs
+++ b/monument/lib/src/layout/new/coursewise.rs
@@ -6,10 +6,10 @@ use std::{
 use bellframe::{Mask, Row, RowBuf, Stage};
 use index_vec::IndexVec;
 
-use super::{utils::CourseHeadMask, Boundary, Error, Result, SpliceStyle};
+use super::{utils::CourseHeadMask, Boundary, Error, Result};
 use crate::{
     layout::{BlockIdx, BlockVec, Layout, Link, RowIdx, StartOrEnd},
-    CallIdx, CallVec,
+    CallIdx, CallVec, SpliceStyle,
 };
 
 /// Generate a [`Layout`] such that chunks will be labelled by their course-head, rather than by

--- a/monument/lib/src/layout/new/leadwise.rs
+++ b/monument/lib/src/layout/new/leadwise.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use bellframe::{Mask, Row, RowBuf};
 use index_vec::IndexVec;
 
-use super::{Boundary, Result, SpliceStyle};
+use super::{Boundary, Result};
 use crate::{
     layout::{BlockIdx, BlockVec, Layout, Link, LinkVec, MethodBlock, RowIdx, StartOrEnd},
-    CallVec,
+    CallVec, SpliceStyle,
 };
 
 /// Prefix inserted at the front of every leadwise composition to allow it to be parsed as such

--- a/monument/lib/src/layout/new/leadwise.rs
+++ b/monument/lib/src/layout/new/leadwise.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use bellframe::{Mask, Row, RowBuf};
 use index_vec::IndexVec;
 
-use super::{Boundary, Result};
+use super::{Boundary, Result, SpliceStyle};
 use crate::{
     layout::{BlockIdx, BlockVec, Layout, Link, LinkVec, MethodBlock, RowIdx, StartOrEnd},
     CallVec,
@@ -13,7 +13,11 @@ use crate::{
 const LEADWISE_PREFIX: &str = "#";
 
 /// Creates a `Layout` where every course is exactly one lead long.
-pub fn leadwise(methods: &[super::Method], calls: &CallVec<super::Call>) -> Result<Layout> {
+pub fn leadwise(
+    methods: &[super::Method],
+    calls: &CallVec<super::Call>,
+    splice_style: SpliceStyle,
+) -> Result<Layout> {
     super::utils::check_duplicate_shorthands(methods)?;
 
     let stage = methods
@@ -37,7 +41,7 @@ pub fn leadwise(methods: &[super::Method], calls: &CallVec<super::Call>) -> Resu
     Ok(Layout {
         starts: start_or_ends(&lead_head_mask, methods, Boundary::Start),
         ends: start_or_ends(&lead_head_mask, methods, Boundary::End),
-        links: links(methods, calls, &lead_head_mask),
+        links: links(methods, calls, &lead_head_mask, splice_style),
         method_blocks,
         stage,
         leadwise: true,
@@ -95,6 +99,7 @@ fn links(
     methods: &[super::Method],
     calls: &CallVec<super::Call>,
     lead_head_mask: &Mask,
+    splice_style: SpliceStyle,
 ) -> LinkVec<Link> {
     let mut call_starts: Vec<HashMap<&str, Vec<CallStart>>> = Vec::new();
     // Maps each lead label to where calls of that label can **end**
@@ -128,18 +133,16 @@ fn links(
         call_starts.push(call_starts_for_this_method);
     }
 
-    // Place calls between every `call_start` and every `call_end` of that lead label
     let mut links = Vec::new();
-    for (method_idx, _method) in methods.iter().enumerate() {
+    // Place calls between every `call_start` and every `call_end` of that lead label
+    for call_starts_by_label in &call_starts {
         for (call_idx, call) in calls.iter_enumerated() {
             let label = call.lead_location.as_str();
-            let starts = &call_starts[method_idx][label];
-            let ends = &call_ends[label];
 
-            for start in starts {
+            for start in &call_starts_by_label[label] {
                 let mut row_after_call = start.row_before.clone();
                 call.place_not.permute(&mut row_after_call).unwrap();
-                for end in ends {
+                for end in &call_ends[label] {
                     // Call
                     links.push(Link {
                         from: start.row_idx,
@@ -151,7 +154,21 @@ fn links(
                         call_idx: Some(call_idx),
                         calling_position: String::new(),
                     });
-                    // Plain
+                }
+            }
+        }
+    }
+    // Place plain links between every pair of the same method label (upholding `splice_style` if
+    // needed
+    for call_starts_by_label in &call_starts {
+        for (label, starts) in call_starts_by_label {
+            for start in starts {
+                for end in &call_ends[label] {
+                    if splice_style == SpliceStyle::Calls
+                        && start.row_idx.block != end.row_idx.block
+                    {
+                        continue; // Don't put a splice, because this isn't a call
+                    }
                     links.push(plain_link(
                         start.row_idx,
                         end.row_idx,
@@ -163,25 +180,23 @@ fn links(
         }
     }
 
-    // Always add plain links at the end of every lead.  In nearly all cases, these will already
-    // exist and be deduplicated, but if there are no calls at the end of each lead (e.g. in
-    // link-cyclic or Stedman) then these will have to be generated separately.
+    // Always add **non-splice** plain links at the end of every lead.  In nearly all cases, these
+    // will already exist and be deduplicated, but if there are no calls at the end of each lead
+    // (e.g. in link-cyclic or Stedman) then these will have to be generated separately.
     for (method_idx_from, method_from) in methods.iter().enumerate() {
-        for (method_idx_to, _) in methods.iter().enumerate() {
-            links.push(plain_link(
-                RowIdx {
-                    block: method_idx_from.into(),
-                    // - 1 to refer to the lead **end** not the lead **head**
-                    row: method_from.lead_len() - 1,
-                },
-                RowIdx {
-                    block: method_idx_to.into(),
-                    row: 0,
-                },
-                lead_head_mask,
-                method_from.lead_head().to_owned(),
-            ));
-        }
+        links.push(plain_link(
+            RowIdx {
+                block: method_idx_from.into(),
+                // - 1 to refer to the lead **end** not the lead **head**
+                row: method_from.lead_len() - 1,
+            },
+            RowIdx {
+                block: method_idx_from.into(),
+                row: 0,
+            },
+            lead_head_mask,
+            method_from.lead_head().to_owned(),
+        ));
     }
 
     // Deduplicate links and return

--- a/monument/lib/src/layout/new/mod.rs
+++ b/monument/lib/src/layout/new/mod.rs
@@ -7,9 +7,8 @@ use std::{
 
 use bellframe::{method::RowAnnot, Bell, Block, Mask, PlaceNot, Row, Stage};
 use itertools::Itertools;
-use serde::Deserialize;
 
-use crate::CallVec;
+use crate::{CallVec, SpliceStyle};
 
 use super::{Layout, MethodBlock};
 
@@ -131,26 +130,6 @@ impl Display for Error {
 impl std::error::Error for Error {}
 
 pub type Result<T> = std::result::Result<T, Error>;
-
-/// The different styles of spliced that can be generated
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize)]
-pub enum SpliceStyle {
-    /// Splices could happen at any lead label
-    #[serde(rename = "leads")]
-    LeadLabels,
-    /// Splice only happen whenever a call _could_ have happened
-    #[serde(rename = "call locations")]
-    CallLocations,
-    /// Splices only happen when calls are actually made
-    #[serde(rename = "calls")]
-    Calls,
-}
-
-impl Default for SpliceStyle {
-    fn default() -> Self {
-        Self::LeadLabels
-    }
-}
 
 #[derive(Debug, Clone)]
 pub enum CourseHeadMaskPreset {

--- a/monument/lib/src/layout/new/mod.rs
+++ b/monument/lib/src/layout/new/mod.rs
@@ -35,7 +35,7 @@ impl Layout {
         });
 
         if leadwise {
-            leadwise::leadwise(&methods, calls)
+            leadwise::leadwise(&methods, calls, splice_style)
         } else {
             coursewise::coursewise(methods, calls, splice_style)
         }

--- a/monument/lib/src/lib.rs
+++ b/monument/lib/src/lib.rs
@@ -9,6 +9,7 @@ pub mod music;
 mod search;
 pub mod utils;
 
+use serde::Deserialize;
 pub use utils::OptRange;
 
 use itertools::Itertools;
@@ -40,6 +41,7 @@ pub struct Query {
     pub len_range: Range<usize>,
     pub num_comps: usize,
     pub allow_false: bool,
+    pub splice_style: SpliceStyle,
 
     pub calls: CallVec<CallType>,
     pub part_head: RowBuf,
@@ -59,6 +61,26 @@ impl Query {
 
     pub fn num_parts(&self) -> usize {
         self.part_head.order()
+    }
+}
+
+/// The different styles of spliced that can be generated
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize)]
+pub enum SpliceStyle {
+    /// Splices could happen at any lead label
+    #[serde(rename = "leads")]
+    LeadLabels,
+    /// Splice only happen whenever a call _could_ have happened
+    #[serde(rename = "call locations")]
+    CallLocations,
+    /// Splices only happen when calls are actually made
+    #[serde(rename = "calls")]
+    Calls,
+}
+
+impl Default for SpliceStyle {
+    fn default() -> Self {
+        Self::LeadLabels
     }
 }
 

--- a/monument/lib/src/search/graph.rs
+++ b/monument/lib/src/search/graph.rs
@@ -19,6 +19,8 @@ pub struct Graph {
 
 #[derive(Debug, Clone)]
 pub struct Chunk {
+    pub id: ChunkId,
+
     pub score: Score,
     pub music_counts: Counts, // PERF: This is only used when reconstructing compositions
 
@@ -100,6 +102,8 @@ impl Graph {
                     .collect_vec();
 
                 Chunk {
+                    id: from_id,
+
                     score: source_chunk.score(),
                     music_counts: source_chunk.music().counts.clone(),
 

--- a/monument/lib/src/search/mod.rs
+++ b/monument/lib/src/search/mod.rs
@@ -10,7 +10,7 @@ use bit_vec::BitVec;
 use itertools::Itertools;
 
 use crate::{
-    layout::{LinkIdx, StartIdx},
+    layout::{BlockIdx, LinkIdx, StartIdx},
     music::Score,
     utils::{coprime_bitmap, Counts, Rotation},
     Comp, CompInner, Progress, Query, QueryUpdate,
@@ -75,7 +75,7 @@ pub(crate) fn search(
     while let Some(prefix) = frontier.pop() {
         let CompPrefix {
             inner,
-            avg_score,
+            avg_score: _, // We recompute this because splices over the part head might change `score`
             length,
         } = prefix;
         let PrefixInner {
@@ -85,7 +85,7 @@ pub(crate) fn search(
             rotation,
             len_since_non_duffer,
 
-            score,
+            mut score,
             method_counts,
         } = *inner;
         let chunk = &graph.chunks[chunk_idx];
@@ -101,8 +101,17 @@ pub(crate) fn search(
                 && method_counts.is_feasible(0, &method_count_ranges)
                 && rotation_bitmap & (1 << rotation) != 0
             {
-                let (start_idx, start_chunk_label, links, music_counts) =
-                    path.flatten(&graph, &query);
+                let FlattenOutput {
+                    start_idx,
+                    start_chunk_label,
+                    links,
+                    music_counts,
+                    splice_over_part_head,
+                } = path.flatten(&graph, &query);
+                // Add/subtract weights from the splices over the part head
+                if splice_over_part_head {
+                    score += (query.num_parts() - 1) as f32 * query.splice_weight;
+                }
                 let comp = Comp {
                     query: query.clone(),
 
@@ -117,7 +126,7 @@ pub(crate) fn search(
                         method_counts,
                         music_counts,
                         total_score: score,
-                        avg_score,
+                        avg_score: score / length as f32,
                     },
                 };
                 update_channel.send(QueryUpdate::Comp(comp)).unwrap();
@@ -329,27 +338,54 @@ enum CompPath {
     Cons(Rc<Self>, LinkIdx, ChunkIdx),
 }
 
+struct FlattenOutput {
+    start_idx: StartIdx,
+    start_chunk_label: String,
+    links: Vec<(LinkIdx, String)>,
+    music_counts: Counts,
+    /// `true` if a single part of the composition finishes on a different method to which it
+    /// started (i.e. there would possibly be a splice over the part-head).
+    splice_over_part_head: bool,
+}
+
+/// Data passed back up the call stack from `flatten_recursive`
+struct RecursiveFlattenOutput {
+    start_idx: StartIdx,
+    start_chunk_label: String,
+    first_block_idx: BlockIdx,
+    last_block_idx: BlockIdx,
+}
+
 impl CompPath {
-    fn flatten(
-        &self,
-        graph: &Graph,
-        query: &Query,
-    ) -> (StartIdx, String, Vec<(LinkIdx, String)>, Counts) {
+    fn flatten(&self, graph: &Graph, query: &Query) -> FlattenOutput {
         let mut links = Vec::new();
         let mut music_counts = Counts::zeros(query.music_types.len());
-        let (start_idx, start_chunk_label) =
-            self.flatten_recursive(graph, query, &mut links, &mut music_counts);
-        (start_idx, start_chunk_label, links, music_counts)
+        let flatten_output = self.flatten_recursive(graph, query, &mut links, &mut music_counts);
+        FlattenOutput {
+            start_idx: flatten_output.start_idx,
+            start_chunk_label: flatten_output.start_chunk_label,
+            links,
+            music_counts,
+            splice_over_part_head: flatten_output.first_block_idx != flatten_output.last_block_idx,
+        }
     }
 
-    /// Recursively flatten `self`, returning the index and label of the start chunk
+    /// Recursively flatten `self`, returning
+    /// ```text
+    /// (
+    ///     index of start chunk,
+    ///     string of the start chunk,
+    ///     BlockIdx of first chunk,
+    ///     BlockIdx of last chunk,
+    /// )
+    /// ```
     fn flatten_recursive(
         &self,
         graph: &Graph,
         query: &Query,
         link_vec: &mut Vec<(LinkIdx, String)>,
         music_counts: &mut Counts,
-    ) -> (StartIdx, String) {
+    ) -> RecursiveFlattenOutput {
         match self {
             Self::Start(start_idx) => {
                 let (start_chunk_idx, _, _) = graph
@@ -359,14 +395,30 @@ impl CompPath {
                     .unwrap();
                 let start_chunk = &graph.chunks[*start_chunk_idx];
                 *music_counts += &start_chunk.music_counts;
-                (*start_idx, start_chunk.label.clone())
+                let start_block_idx = start_chunk
+                    .id
+                    .row_idx()
+                    .expect("Can't start with a 0-length end chunk")
+                    .block;
+                RecursiveFlattenOutput {
+                    start_idx: *start_idx,
+                    start_chunk_label: start_chunk.label.clone(),
+                    first_block_idx: start_block_idx,
+                    last_block_idx: start_block_idx,
+                }
             }
             Self::Cons(lhs, link, chunk_idx) => {
-                let start = lhs.flatten_recursive(graph, query, link_vec, music_counts);
+                // Recursively flatten all previous links in the list
+                let mut output = lhs.flatten_recursive(graph, query, link_vec, music_counts);
+                // Update music counts and list the links used
                 let chunk = &graph.chunks[*chunk_idx];
                 *music_counts += &chunk.music_counts;
                 link_vec.push((*link, chunk.label.clone()));
-                start
+                // Update the `last_block_idx` and propagate the output
+                if let Some(row_idx) = chunk.id.row_idx() {
+                    output.last_block_idx = row_idx.block;
+                }
+                output
             }
         }
     }

--- a/monument/test/cases/cyclic-callwise.toml
+++ b/monument/test/cases/cyclic-callwise.toml
@@ -1,0 +1,8 @@
+length = "QP"
+methods = ["Little Bob Major", "Plain Bob Major"]
+music_file = "music-8.toml"
+splice_style = "calls"
+part_head = "18234567"
+method_count = { min = 400, max = 800 }
+bob_weight = -6
+single_weight = -8

--- a/monument/test/cases/plain-splice-over-part-head-2.toml
+++ b/monument/test/cases/plain-splice-over-part-head-2.toml
@@ -1,0 +1,21 @@
+# This tests that, if `splice_style = "calls"`, no plain splices are taken (even over the part
+# head).  In this case, `D[xB]N` shouldn't be emitted.
+length = { min = 0, max = 800 }
+part_head = "1342"
+course_heads = ["*5678"]
+
+methods = [
+    "Deva Surprise Major",
+    { title = "Double Norwich Court Bob Major", shorthand = "N" },
+]
+method_count = { min = 0, max = 800 }
+splice_style = "calls"
+splice_weight = 1
+
+bob_weight = 0
+single_weight = 0
+
+[[calls]]
+symbol = "x"
+place_notation = "16"
+weight = 0

--- a/monument/test/cases/plain-splice-over-part-head.toml
+++ b/monument/test/cases/plain-splice-over-part-head.toml
@@ -1,0 +1,18 @@
+# This tests that, if `splice_style = "calls"`, no plain splices are taken (even over the part
+# head).  In this case, neither `D[xB]Y` or `Y[xB]DDDDD` should be emitted.
+length = { min = 0, max = 800 }
+part_head = "1342"
+course_heads = ["*5678"]
+
+methods = ["Deva Surprise Major", "Ytterbium Surprise Major"]
+method_count = { min = 0, max = 800 }
+splice_style = "calls"
+splice_weight = 1
+
+bob_weight = 0
+single_weight = 0
+
+[[calls]]
+symbol = "x"
+place_notation = "16"
+weight = 0

--- a/monument/test/cases/splice-over-part-head.toml
+++ b/monument/test/cases/splice-over-part-head.toml
@@ -1,0 +1,10 @@
+length = { min = 0, max = 800 }
+part_head = "1342"
+course_heads = ["*5678"]
+
+methods = ["Yorkshire Surprise Major", "Cornwall Surprise Major"]
+method_count = { min = 0, max = 800 }
+splice_weight = 1
+
+bob_weight = 0
+single_weight = 0

--- a/monument/test/cases/splice-over-part-head.toml
+++ b/monument/test/cases/splice-over-part-head.toml
@@ -1,3 +1,5 @@
+# This tests that splices over part heads are counted.  For example `CY[H]x3` should have a weight
+# of 5 (splices), not 3 (as you'd get if you discounted splices over the part heads).
 length = { min = 0, max = 800 }
 part_head = "1342"
 course_heads = ["*5678"]

--- a/monument/test/results.json
+++ b/monument/test/results.json
@@ -3116,6 +3116,14 @@
       { "length": 112, "string": "", "avg_score": 0.0 }
     ]
   },
+  "test/cases/splice-over-part-head.toml": {
+    "comps": [
+      { "length": 384, "string": "CCCC[H]", "avg_score": 0.0, "part_head": "14235678" },
+      { "length": 672, "string": "YYYYYYY[H]", "avg_score": 0.0, "part_head": "14235678" },
+      { "length": 480, "string": "YYYYC[H]", "avg_score": 0.010416667, "part_head": "14235678" },
+      { "length": 192, "string": "CY[H]", "avg_score": 0.026041666, "part_head": "14235678" }
+    ]
+  },
   "test/cases/splice-weight-1.toml": {
     "comps": [
       { "length": 224, "string": "#CCCCCCC", "avg_score": 0.0 },

--- a/monument/test/results.json
+++ b/monument/test/results.json
@@ -268,6 +268,610 @@
       { "length": 224, "string": "YYYYYCC", "avg_score": 0.0 }
     ]
   },
+  "test/cases/cyclic-callwise.toml": {
+    "comps": [
+      {
+        "length": 1288,
+        "string": "#PPP[-]L[-]LLLLL[-]LLLLLLL[-]PP[-]",
+        "avg_score": -0.06832298,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[s]LLL[-]LLLLLL[s]L[-]P[-]",
+        "avg_score": -0.067708336,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[-]L[-]LL[-]LLLLL[-]P[-]LL[-]P",
+        "avg_score": -0.067708336,
+        "part_head": "16782345"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[s]LLLLLL[-]P[s]LLLLLL[-]LL[-]",
+        "avg_score": -0.067708336,
+        "part_head": "18234567"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPPP[s]L[s]L[s]LLLL[-]LLL[s]",
+        "avg_score": -0.06754658,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[-]P[-]LLL[s]LLLL[s]LL[-]",
+        "avg_score": -0.06754658,
+        "part_head": "16782345"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPP[s]PP[-]LLL[s]LLLLLL[-]LL[-]",
+        "avg_score": -0.06754658,
+        "part_head": "18234567"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[s]LLL[s]LLL[-]LLL[s]L[s]P",
+        "avg_score": -0.06696428,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[s]LLL[s]LLLLLLL[s]LL[s]P",
+        "avg_score": -0.06696428,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[s]LL[s]LLLLLLL[s]LLL[s]P",
+        "avg_score": -0.06696428,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[-]P[-]LLLLLLL[-]LLL[s]PP[s]",
+        "avg_score": -0.06696428,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[s]LLLLLL[s]LLLLLL[s]PP[s]",
+        "avg_score": -0.06696428,
+        "part_head": "16782345"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[-]LL[-]LL[-]P[-]L[-]LLLL[-]",
+        "avg_score": -0.06677019,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[s]LLLL[-]LLL[-]LLL[-]PP[s]",
+        "avg_score": -0.06622024,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[-]LL[-]LLLLLL[s]P[-]LLLLLL[s]",
+        "avg_score": -0.06622024,
+        "part_head": "18234567"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[s]L[-]LL[-]LL[-]LLLLLL[s]",
+        "avg_score": -0.065993786,
+        "part_head": "18234567"
+      },
+      {
+        "length": 1288,
+        "string": "#PP[-]LLL[-]PPPP[-]LLL[-]LLL[-]LL[-]",
+        "avg_score": -0.065993786,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[s]PP[-]LLL[-]LLL[-]LLLL[s]P",
+        "avg_score": -0.065476194,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPP[-]LL[-]LLLLLL[s]LLL[-]PP[s]",
+        "avg_score": -0.06521739,
+        "part_head": "18234567"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[-]LL[-]LL[-]LLL[-]L[-]LLLL[-]",
+        "avg_score": -0.0639881,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[s]L[-]LL[-]LLLLLL[s]LLL[-]",
+        "avg_score": -0.0639881,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[-]L[-]LLLLL[-]P[s]LLLLLL[s]",
+        "avg_score": -0.0639881,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[s]LLLLLL[s]P[-]LLLLL[-]L[-]P",
+        "avg_score": -0.0639881,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PPP[s]LLLLLLL[s]PP[s]LLLLL[s]P",
+        "avg_score": -0.0639881,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[-]LL[s]LLLLLLL[-]L[s]L[-]",
+        "avg_score": -0.06366459,
+        "part_head": "18234567"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPP[s]PP[s]LLL[-]LLLLL[-]L[-]P",
+        "avg_score": -0.06366459,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[s]L[-]LL[-]LLLLLL[-]LLL[s]",
+        "avg_score": -0.063244045,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[-]LL[-]P[-]LLLLL[-]LL[-]L[-]P",
+        "avg_score": -0.063244045,
+        "part_head": "16782345"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[s]PP[-]P[s]LLLLLLL[-]LLL[-]",
+        "avg_score": -0.063244045,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[s]L[-]LL[-]LLLLLL[s]P[-]",
+        "avg_score": -0.0628882,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[-]LLL[-]P[s]LLLL[s]LL[-]",
+        "avg_score": -0.062111802,
+        "part_head": "16782345"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPP[-]L[-]LLLLL[-]LLL[s]PP[s]",
+        "avg_score": -0.062111802,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PP[-]P[-]PPPP[-]LLL[-]LLLL[-]LLL[-]",
+        "avg_score": -0.06175595,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[s]L[-]LL[-]LLLLLL[-]P[s]",
+        "avg_score": -0.061335403,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[-]LLL[s]LLL[s]LLL[s]L[s]P",
+        "avg_score": -0.061011903,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[-]LLL[-]LLLLLLL[s]P[-]PP[s]",
+        "avg_score": -0.06026786,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[s]PP[-]LLL[s]LLLLLLL[-]P[-]",
+        "avg_score": -0.05952381,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1288,
+        "string": "#LLLLL[s]PPPPPPP[-]L[s]LL[-]L",
+        "avg_score": -0.05900621,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[-]LLLL[-]L[-]LLLLL[s]LL[s]",
+        "avg_score": -0.05877976,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[-]LLL[s]LLLLL[-]L[s]LLL[-]",
+        "avg_score": -0.05877976,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[-]P[-]LLLLLLL[s]LLL[-]PP[s]",
+        "avg_score": -0.05877976,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[-]LLL[s]LLLLL[-]L[-]LLL[s]",
+        "avg_score": -0.058035713,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PP[-]LLL[-]PPPP[-]LLL[-]LLLL[-]P[-]",
+        "avg_score": -0.058035713,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[-]LLL[s]LLLLL[-]L[s]P[-]",
+        "avg_score": -0.057453416,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[-]L[-]LLLL[-]LLLLL[s]L[s]",
+        "avg_score": -0.057453416,
+        "part_head": "18234567"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[-]LL[-]LLLL[-]LLLL[-]LL[-]P",
+        "avg_score": -0.05654762,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1288,
+        "string": "#LLLL[-]PPP[-]LLLLLLL[-]PP[-]LL",
+        "avg_score": -0.055900622,
+        "part_head": "14567823"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[-]LLL[s]LLLLL[-]L[-]P[s]",
+        "avg_score": -0.055900622,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[-]L[-]LL[s]LL[-]LLLLLL[s]",
+        "avg_score": -0.055900622,
+        "part_head": "18234567"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[-]L[-]LLLLL[s]P[-]LLLLLL[s]",
+        "avg_score": -0.055059522,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[s]LLLLLL[-]P[s]LLLLL[-]L[-]P",
+        "avg_score": -0.055059522,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPP[s]PP[-]LLL[s]LLLLL[-]L[-]P",
+        "avg_score": -0.054347824,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[-]LLL[s]LLLLLL[s]L[-]P[-]",
+        "avg_score": -0.054315478,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[-]L[-]LL[s]LLLLLL[s]LLL[-]",
+        "avg_score": -0.054315478,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#LLLLL[s]PPPPPPP[s]L[-]LLL[-]L",
+        "avg_score": -0.05357143,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[-]L[-]LL[s]LLLLLL[-]LLL[s]",
+        "avg_score": -0.05357143,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPP[-]L[-]LLLLL[s]LLL[-]PP[s]",
+        "avg_score": -0.05357143,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[-]L[-]LL[s]LLLLLL[s]P[-]",
+        "avg_score": -0.05279503,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[s]LLLL[s]LLL[s]LL[s]P",
+        "avg_score": -0.05279503,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#LLLLLL[-]LL[s]PPPPPPP[s]L[-]L",
+        "avg_score": -0.052083332,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1344,
+        "string": "#LLLLLL[-]L[s]PPPPPPP[s]LL[-]L",
+        "avg_score": -0.052083332,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[-]LLL[-]LLL[s]LLLL[s]LL[-]",
+        "avg_score": -0.052083332,
+        "part_head": "16782345"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[-]LL[-]L[-]LL[-]LL[-]LLL[-]P",
+        "avg_score": -0.052083332,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[-]L[-]LL[s]LLLLLL[-]P[s]",
+        "avg_score": -0.051242236,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[s]LLLL[s]LLLLLLL[s]L[s]P",
+        "avg_score": -0.05059524,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[s]L[s]LLLLLLL[s]LLLL[s]P",
+        "avg_score": -0.05059524,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[s]LLLLL[s]P[s]LLLLLLL[s]",
+        "avg_score": -0.04985119,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[s]LLLLLLL[s]P[s]LLLLL[s]P",
+        "avg_score": -0.04985119,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPP[-]LLL[s]LLLLL[-]LLL[s]P",
+        "avg_score": -0.048136648,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPP[-]LLL[s]LLLLL[s]LLL[-]P",
+        "avg_score": -0.048136648,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPP[-]P[-]LLLLLLL[s]LL[s]P",
+        "avg_score": -0.048136648,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPP[s]LLL[-]LLLLL[s]LLL[-]P",
+        "avg_score": -0.048136648,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPP[s]LL[s]LLLLLLL[-]P[-]P",
+        "avg_score": -0.048136648,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[s]PPP[s]LLLL[-]LLLLLL[-]",
+        "avg_score": -0.04761905,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[-]LLL[-]LLLLLLL[s]LL[s]P",
+        "avg_score": -0.04613095,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[s]LL[s]LLLLLLL[-]LLL[-]P",
+        "avg_score": -0.04613095,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[-]LLLLLL[-]LLLL[s]PPP[s]",
+        "avg_score": -0.04613095,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#P[-]LLLLLLL[-]PPPPP[-]LLL[-]LL",
+        "avg_score": -0.04613095,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[-]L[s]LLLL[-]LL[s]LL[-]P",
+        "avg_score": -0.045807455,
+        "part_head": "18234567"
+      },
+      {
+        "length": 1344,
+        "string": "#LLL[-]LLLLLLL[-]PPPPP[-]P[-]LL",
+        "avg_score": -0.04464286,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPP[-]LL[s]LL[-]LLLL[s]L[-]PP",
+        "avg_score": -0.044254657,
+        "part_head": "18234567"
+      },
+      {
+        "length": 1288,
+        "string": "#P[-]LLLLLLL[-]PPPPP[-]P[-]LL",
+        "avg_score": -0.044254657,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[-]LLL[-]LLL[s]LLL[-]L[s]P",
+        "avg_score": -0.039434522,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[s]LLLLL[-]P[-]LLLLLLL[s]",
+        "avg_score": -0.03794643,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[s]LLLLLLL[-]P[-]LLLLL[s]P",
+        "avg_score": -0.03497024,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPP[s]L[s]LLL[-]LLL[-]LLL[-]PP",
+        "avg_score": -0.03348214,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[-]LLL[-]LLL[-]LLL[s]L[s]P",
+        "avg_score": -0.032738097,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPP[s]LLLL[-]LLL[-]LL[s]P",
+        "avg_score": -0.031055901,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPP[s]LL[-]LLL[-]LLLL[s]PP",
+        "avg_score": -0.031055901,
+        "part_head": "13456782"
+      },
+      {
+        "length": 1344,
+        "string": "#PP[-]LLL[-]PPPP[s]LLLLLLL[s]P",
+        "avg_score": -0.029761905,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1344,
+        "string": "#PP[-]LLL[-]PPP[s]LLLLLLL[s]PP",
+        "avg_score": -0.029761905,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1344,
+        "string": "#PP[-]LLL[-]PPPPP[s]LLLLLLL[s]",
+        "avg_score": -0.01264881,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1344,
+        "string": "#PP[-]LLL[-]PP[s]LLLLLLL[s]PPP",
+        "avg_score": -0.01264881,
+        "part_head": "17823456"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPPPP[s]LLLLLL[s]LLLLLL[-]",
+        "avg_score": -0.002232143,
+        "part_head": "16782345"
+      },
+      {
+        "length": 1344,
+        "string": "#PPPP[-]LLLLLL[s]LLLLLL[s]PP",
+        "avg_score": -0.00074404763,
+        "part_head": "16782345"
+      },
+      {
+        "length": 1344,
+        "string": "#LLLLL[-]PPPPPP[-]LLLLL[-]LL",
+        "avg_score": 0.002232143,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1344,
+        "string": "#LLLLLLL[-]LLLLL[-]PPPPPP[-]",
+        "avg_score": 0.0029761905,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1288,
+        "string": "#PPP[-]LLL[s]LLLLLL[s]PPPP",
+        "avg_score": 0.0124223605,
+        "part_head": "16782345"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPPP[-]LLLLL[-]LLLL[-]",
+        "avg_score": 0.049689442,
+        "part_head": "15678234"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPP[-]LLLL[-]LLLLL[-]PPP",
+        "avg_score": 0.049689442,
+        "part_head": "15678234"
+      }
+    ]
+  },
   "test/cases/cyclic-no-calls.toml": {
     "comps": [
       { "length": 1344, "string": "#LDYSDS", "avg_score": 0.026041666, "part_head": "14567823" },
@@ -914,7 +1518,7 @@
       },
       {
         "length": 1288,
-        "string": "#PL[-]LPL[-]LLPL[-]LPL[-]LP[-]L[-]L[-]P",
+        "string": "#PL[-]LPL[-]LPLL[-]LPL[-]LP[-]L[-]L[-]P",
         "avg_score": 0.07748448,
         "part_head": "16782345"
       },

--- a/monument/test/results.json
+++ b/monument/test/results.json
@@ -271,6 +271,18 @@
   "test/cases/cyclic-callwise.toml": {
     "comps": [
       {
+        "length": 1344,
+        "string": "#PPPP[s]PP[s]LLLLLL[s]LLLLLL[s]",
+        "avg_score": -0.06845238,
+        "part_head": "16782345"
+      },
+      {
+        "length": 1288,
+        "string": "#PPPPPPP[s]L[s]L[s]LLLL[s]LLL[-]",
+        "avg_score": -0.06832298,
+        "part_head": "13456782"
+      },
+      {
         "length": 1288,
         "string": "#PPP[-]L[-]LLLLL[-]LLLLLLL[-]PP[-]",
         "avg_score": -0.06832298,
@@ -733,12 +745,6 @@
         "part_head": "13456782"
       },
       {
-        "length": 1344,
-        "string": "#P[-]LLLLLLL[-]PPPPP[-]LLL[-]LL",
-        "avg_score": -0.04613095,
-        "part_head": "17823456"
-      },
-      {
         "length": 1288,
         "string": "#PPPPPP[-]L[s]LLLL[-]LL[s]LL[-]P",
         "avg_score": -0.045807455,
@@ -755,12 +761,6 @@
         "string": "#PPPPP[-]LL[s]LL[-]LLLL[s]L[-]PP",
         "avg_score": -0.044254657,
         "part_head": "18234567"
-      },
-      {
-        "length": 1288,
-        "string": "#P[-]LLLLLLL[-]PPPPP[-]P[-]LL",
-        "avg_score": -0.044254657,
-        "part_head": "17823456"
       },
       {
         "length": 1344,
@@ -3081,6 +3081,74 @@
       { "length": 224, "string": "<BBBBBBB>", "avg_score": 0.0 },
       { "length": 224, "string": "BBBBBBB", "avg_score": 0.0 },
       { "length": 224, "string": "YYYYYYY", "avg_score": 0.0 }
+    ]
+  },
+  "test/cases/plain-splice-over-part-head-2.toml": {
+    "comps": [
+      { "length": 192, "string": "DD[H]", "avg_score": 0.0, "part_head": "14235678" },
+      { "length": 384, "string": "DD[sH]D[xB]D[sH]", "avg_score": 0.0, "part_head": "14235678" },
+      { "length": 672, "string": "D[xB]DDDDDD", "avg_score": 0.0, "part_head": "13425678" },
+      { "length": 384, "string": "D[xB]D[sH]DD[sH]", "avg_score": 0.0, "part_head": "13425678" },
+      { "length": 336, "string": "NNNNNN[xB]N", "avg_score": 0.0, "part_head": "13425678" },
+      { "length": 240, "string": "NNNNN[H]", "avg_score": 0.0, "part_head": "14235678" },
+      {
+        "length": 432,
+        "string": "D[xB]D[sH]NNNNN[sH]",
+        "avg_score": 0.011574074,
+        "part_head": "13425678"
+      },
+      {
+        "length": 432,
+        "string": "NNNNN[sH]D[xB]D[sH]",
+        "avg_score": 0.011574074,
+        "part_head": "14235678"
+      }
+    ]
+  },
+  "test/cases/plain-splice-over-part-head.toml": {
+    "comps": [
+      { "length": 192, "string": "DD[H]", "avg_score": 0.0, "part_head": "14235678" },
+      { "length": 384, "string": "DD[sH]D[xB]D[sH]", "avg_score": 0.0, "part_head": "14235678" },
+      { "length": 672, "string": "D[xB]DDDDDD", "avg_score": 0.0, "part_head": "13425678" },
+      { "length": 384, "string": "D[xB]D[sH]DD[sH]", "avg_score": 0.0, "part_head": "13425678" },
+      { "length": 672, "string": "YYYYYYY[H]", "avg_score": 0.0, "part_head": "14235678" },
+      { "length": 192, "string": "Y[xB]Y", "avg_score": 0.0, "part_head": "13425678" },
+      {
+        "length": 384,
+        "string": "DD[sH]D[xB]Y[sH]",
+        "avg_score": 0.013020833,
+        "part_head": "14235678"
+      },
+      {
+        "length": 384,
+        "string": "DD[sH]Y[xB]Y[sH]",
+        "avg_score": 0.013020833,
+        "part_head": "14235678"
+      },
+      {
+        "length": 384,
+        "string": "Y[xB]D[sH]DD[sH]",
+        "avg_score": 0.013020833,
+        "part_head": "13425678"
+      },
+      {
+        "length": 384,
+        "string": "Y[xB]Y[sH]DD[sH]",
+        "avg_score": 0.013020833,
+        "part_head": "13425678"
+      },
+      {
+        "length": 384,
+        "string": "DD[sH]Y[xB]D[sH]",
+        "avg_score": 0.015625,
+        "part_head": "14235678"
+      },
+      {
+        "length": 384,
+        "string": "D[xB]Y[sH]DD[sH]",
+        "avg_score": 0.015625,
+        "part_head": "13425678"
+      }
     ]
   },
   "test/cases/self-false-1.toml": {


### PR DESCRIPTION
Fixes 3 bugs:
- `splice_style = "calls"` will no longer generate splices over part heads
- `splice_weight` is now applied to splices over part heads
- `splice_style = "calls"` now works for cyclic compositions