### PR TITLE
More flexible lead locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## (Unreleased)
 
 ### Monument
+- (#91) Allow multiple labels on the same row within a lead.  Also reversed the syntax from e.g.
+    `lead_locations = { 0 = "LE", 16 = "HL" }` to `lead_locations = { LE = 0, HL = 16 }`.  The same
+    label can be added to multiple rows like `lead_locations = { SE = [3, 9] }` (for Six-Ends in
+    Stedman).
 - (#89) Refactor the search algorithm (splitting the node expansion from the best-first search code)
 
 ---
@@ -50,6 +54,9 @@
 
 ### Internal Improvements
 - (#64) Use `goldilocks-json-fmt` to format the test result files.
+
+### BellFrame
+- (#??) Allow multiple lead labels to be placed on the same row
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## (Unreleased)
 
 ### Monument
+- (#91) Calls can now go from/to different lead labels.  Set this with e.g.
+    `lead_location = { from = "2nds", to = "HL" }`.  Useful for adding finer control over where
+    calls can be placed.
 - (#91) Allow multiple labels on the same row within a lead.  Also reversed the syntax from e.g.
     `lead_locations = { 0 = "LE", 16 = "HL" }` to `lead_locations = { LE = 0, HL = 16 }`.  The same
     label can be added to multiple rows like `lead_locations = { SE = [3, 9] }` (for Six-Ends in

--- a/monument/cli/guide.md
+++ b/monument/cli/guide.md
@@ -344,6 +344,39 @@ calling_positions = "LIBFVXSMWH" # Optional; defaults to 'LIBFVXSEN...' with 'MW
 weight = -4            # Optional; Score given to each instance of this call.  Defaults to -3
 ```
 
+Since _v0.9.0_, calls can go from/to different lead labels.  This is useful if, for example, you
+want to make sure you only apply some calls to some methods.  The following example adds `16` bobs
+only in 8ths place methods, and `14` bobs in 2nds place methods (as in
+[Leary's 23](https://complib.org/composition/21607)):
+
+```toml
+length = "QP"
+methods = [
+    { title = "Bristol Surprise Major",     lead_locations = { LE = 0, 8ths = 0 } },
+    { title = "Deva Surprise Major",        lead_locations = { LE = 0, 8ths = 0 } },
+    { title = "Cambridge Surprise Major",   lead_locations = { LE = 0, 2nds = 0 } },
+    { title = "Superlative Surprise Major", lead_locations = { LE = 0, 2nds = 0 } },
+]
+part_head = "13456782"
+
+base_calls = "none" # Only use our own custom calls
+[[calls]]
+symbol = ""
+debug_symbol = "-"
+place_notation = "14"
+lead_location = { from = "2nds", to = "LE" }
+
+[[calls]]
+symbol = "x"
+place_notation = "16"
+lead_location = { from = "8ths", to = "LE" }
+```
+
+Notice how we're using lead labels `2nds` and `8ths` to control which calls are able to be placed at
+the end of a lead of each method.  Also note how all calls lead to `LE`, which means that any method
+can follow any call (if the calls didn't change lead location, then 2nds/8ths place methods couldn't
+be spliced over a call).
+
 ### Music
 
 #### `default_music` _(since v0.8.0)_

--- a/monument/cli/guide.md
+++ b/monument/cli/guide.md
@@ -237,7 +237,7 @@ method = "Bristol Surprise Major"
 [method]
 title = "Lincolnshire Surprise Major"
 shorthand = "N" # (optional; defaults to the first letter of the title)
-lead_locations = { 0: "LE", 16: "HL" } # (optional; defaults to `{0:"LE"}`)
+lead_locations = { LE = 0, HL = 16 } # (optional; defaults to `{ LE = 0 }`)
 # Overrides for global values (all optional):
 count = { min = 224, max = 600 }
 course_heads = ["*78"]
@@ -251,12 +251,20 @@ name = "Double Norwich Court" # Note this is *name*, not *title*
 place_notation = "x4x36x5x8,8"
 stage = 8
 shorthand = "N" # (optional; defaults to the first letter of the title)
-lead_locations = { 0: "LE", 8: "HL" } # (optional; defaults to `{0:"LE"}`)
+lead_locations = { LE = 0, HL = 8 } # (optional; defaults to `{ LE = 0 }`)
 # Overrides for global values (all optional):
 count = { min = 224, max = 600 }
 course_heads = ["*78"]
 start_indices = [2]
 end_indices = [2]
+```
+
+You can also specify multiple locations for the same lead label, useful for e.g. Stedman:
+
+```toml
+[method]
+title = "Stedman Triples"
+lead_locations = { SE = [3, 9] }
 ```
 
 #### `methods`

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -557,13 +557,28 @@ pub struct MethodCommon {
     /// Optional override for method count range
     #[serde(default, rename = "count")]
     count_range: RangeInclusive,
-    /// The inputs to this map are numerical strings representing sub-lead indices, and the
-    /// outputs are the lead location names
-    lead_locations: Option<HashMap<String, String>>,
+    /// Maps labels to where in the lead they occur
+    lead_locations: Option<HashMap<String, LeadLocations>>,
     /// Custom set of course head masks for this method
     course_heads: Option<Vec<String>>,
     start_indices: Option<Vec<isize>>,
     end_indices: Option<Vec<isize>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum LeadLocations {
+    JustOne(isize),
+    Many(Vec<isize>),
+}
+
+impl LeadLocations {
+    fn as_slice(&self) -> &[isize] {
+        match self {
+            Self::JustOne(idx) => std::slice::from_ref(idx),
+            Self::Many(indices) => indices,
+        }
+    }
 }
 
 impl MethodSpec {
@@ -590,19 +605,13 @@ impl MethodSpec {
             }
         }
 
-        for (index_str, name) in self.get_lead_locations() {
-            let index = index_str.parse::<isize>().map_err(|_| {
-                anyhow::Error::msg(format!(
-                    "Lead location {:?} (for label {:?} in {:?}) is not a valid integer",
-                    index_str,
-                    name,
-                    method.title()
-                ))
-            })?;
-            let lead_len = method.lead_len() as isize;
-            let wrapped_index = ((index % lead_len) + lead_len) % lead_len;
-            // This cast is OK because we used % twice to guarantee a positive index
-            method.set_label(wrapped_index as usize, Some(name.clone()));
+        let lead_len = method.lead_len() as isize;
+        for (name, locations) in self.get_lead_locations() {
+            for l in locations.as_slice() {
+                let wrapped_index = ((l % lead_len) + lead_len) % lead_len;
+                // This cast is OK because we used % twice to guarantee a positive index
+                method.add_label(wrapped_index as usize, name.clone());
+            }
         }
 
         let common = self
@@ -619,7 +628,7 @@ impl MethodSpec {
         }
     }
 
-    fn get_lead_locations(&self) -> HashMap<String, String> {
+    fn get_lead_locations(&self) -> HashMap<String, LeadLocations> {
         self.common()
             .and_then(|c| c.lead_locations.clone())
             .unwrap_or_else(default_lead_labels)
@@ -1019,10 +1028,9 @@ fn backstroke() -> Stroke {
 }
 
 /// By default, add a lead location "LE" on the 0th row (i.e. when the place notation repeats).
-#[inline]
-fn default_lead_labels() -> HashMap<String, String> {
+fn default_lead_labels() -> HashMap<String, LeadLocations> {
     let mut labels = HashMap::new();
-    labels.insert("0".to_owned(), LABEL_LEAD_END.to_owned());
+    labels.insert(LABEL_LEAD_END.to_owned(), LeadLocations::JustOne(0));
     labels
 }
 

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -372,7 +372,7 @@ impl Spec {
     ) -> anyhow::Result<()> {
         let sorted_calls = call_specs
             .iter()
-            .map(|call| (get_symbol(call), &call.lead_location, &call.place_not))
+            .map(|call| (get_symbol(call), &call.lead_location_from, &call.place_not))
             .sorted_by_key(|&(sym, lead_loc, _pn)| (sym, lead_loc));
         for ((sym1, lead_location1, pn1), (sym2, lead_location2, pn2)) in
             sorted_calls.tuple_windows()

--- a/monument/lib/src/layout/new/coursewise.rs
+++ b/monument/lib/src/layout/new/coursewise.rs
@@ -133,7 +133,7 @@ fn call_starts_by_label(methods: &[super::Method]) -> HashMap<&str, Vec<RowIdx>>
         // ... for every labelled row ...
         let course_len = d.plain_course.len();
         for (row_idx, annot) in d.plain_course.annots().enumerate() {
-            if let Some(label) = &annot.label {
+            for label in &annot.labels {
                 // ... mark that a similarly-labelled call could be called just before this label
                 let call_start_idx = (row_idx + course_len - 1) % course_len;
 
@@ -169,7 +169,7 @@ fn call_ends(methods: &[super::Method]) -> Vec<CallEnd> {
     for (method_idx, d) in methods.iter().enumerate() {
         // ... for every labelled row in the plain course ...
         for (row_idx, annot_row) in d.plain_course.annot_rows().enumerate() {
-            if annot_row.annot().label.is_some() {
+            if !annot_row.annot().labels.is_empty() {
                 let row_after_call = annot_row.row();
                 // ... for every course head mask ...
                 for (ch_mask_idx, ch_mask) in d.ch_masks.iter().enumerate() {

--- a/monument/lib/src/layout/new/coursewise.rs
+++ b/monument/lib/src/layout/new/coursewise.rs
@@ -274,7 +274,7 @@ fn generate_call_links(
 ) -> Result<()> {
     // Test every call in every valid position in the course ...
     for (call_idx, call) in calls.iter_enumerated() {
-        let lead_label = call.lead_location.as_str();
+        let lead_label = call.lead_location_from.as_str();
         let call_starts = link_gen_data
             .call_starts_by_label
             .get(lead_label)

--- a/monument/lib/src/layout/new/leadwise.rs
+++ b/monument/lib/src/layout/new/leadwise.rs
@@ -108,7 +108,7 @@ fn links(
         let lead = m.first_lead();
         let mut call_starts_for_this_method = HashMap::new();
         for (row_idx_after, annot_row_after) in lead.annot_rows().enumerate() {
-            if let Some(label) = annot_row_after.annot() {
+            for label in annot_row_after.annot() {
                 let row_idx_before = (row_idx_after + lead.len() - 1) % lead.len();
                 let row_before = lead.get_row(row_idx_before).unwrap();
                 let row_after_plain = lead.get_row(row_idx_before + 1).unwrap();
@@ -138,7 +138,6 @@ fn links(
     for call_starts_by_label in &call_starts {
         for (call_idx, call) in calls.iter_enumerated() {
             let label = call.lead_location.as_str();
-
             for start in &call_starts_by_label[label] {
                 let mut row_after_call = start.row_before.clone();
                 call.place_not.permute(&mut row_after_call).unwrap();

--- a/monument/lib/src/layout/new/mod.rs
+++ b/monument/lib/src/layout/new/mod.rs
@@ -273,14 +273,14 @@ impl std::ops::Deref for Method {
 #[derive(Debug, Clone)]
 struct Annot {
     sub_lead_idx: usize,
-    label: Option<String>,
+    labels: Vec<String>,
 }
 
 impl From<RowAnnot<'_>> for Annot {
     fn from(a: RowAnnot) -> Self {
         Self {
-            sub_lead_idx: a.sub_lead_idx(),
-            label: a.label().map(str::to_owned),
+            sub_lead_idx: a.sub_lead_idx,
+            labels: a.labels.to_owned(),
         }
     }
 }

--- a/monument/lib/src/layout/new/mod.rs
+++ b/monument/lib/src/layout/new/mod.rs
@@ -5,7 +5,10 @@ use std::{
     ops::Range,
 };
 
-use bellframe::{method::RowAnnot, Bell, Block, Mask, PlaceNot, Row, RowBuf, Stage};
+use bellframe::{
+    method::{RowAnnot, LABEL_LEAD_END},
+    Bell, Block, Mask, PlaceNot, Row, RowBuf, Stage,
+};
 use itertools::Itertools;
 
 use crate::{CallVec, SpliceStyle};
@@ -296,7 +299,8 @@ pub struct Call {
     pub debug_symbol: String,
     pub calling_positions: Vec<String>,
 
-    pub lead_location: String,
+    pub lead_location_from: String,
+    pub lead_location_to: String,
     pub place_not: PlaceNot,
 
     pub weight: f32,
@@ -340,7 +344,8 @@ impl Call {
             display_symbol: String::new(),
             debug_symbol: "-".to_owned(),
             calling_positions: default_calling_positions(&place_not),
-            lead_location: bellframe::method::LABEL_LEAD_END.to_owned(),
+            lead_location_from: LABEL_LEAD_END.to_owned(),
+            lead_location_to: LABEL_LEAD_END.to_owned(),
             place_not,
             weight: -1.8, // Slightly punish bobs
         }
@@ -352,7 +357,8 @@ impl Call {
             display_symbol: "s".to_owned(),
             debug_symbol: "s".to_owned(),
             calling_positions: default_calling_positions(&place_not),
-            lead_location: bellframe::method::LABEL_LEAD_END.to_owned(),
+            lead_location_from: LABEL_LEAD_END.to_owned(),
+            lead_location_to: LABEL_LEAD_END.to_owned(),
             place_not,
             weight: -2.3, // Punish singles slightly more than bobs
         }

--- a/monument/lib/src/layout/new/utils.rs
+++ b/monument/lib/src/layout/new/utils.rs
@@ -128,7 +128,8 @@ fn filter_bells_fixed_by_call(
     set: &mut HashSet<Bell>,
 ) {
     // Note that all calls are required to only substitute one piece of place notation.
-    for sub_lead_idx_after_call in method.label_indices(&call.lead_location) {
+    for sub_lead_idx_after_call in method.label_indices(&call.lead_location_from) {
+        // TODO: Handle different from/to locations
         let idx_before_call = (sub_lead_idx_after_call + method.lead_len() - 1) % method.lead_len();
         let idx_after_call = idx_before_call + 1; // in range `1..=method.lead_len()`
 

--- a/monument/test/cases/call-from-to-coursewise.toml
+++ b/monument/test/cases/call-from-to-coursewise.toml
@@ -1,0 +1,22 @@
+# Like Leary's 23, these comps use `14` bobs only in 2nds place methods and `16` bobs only in 8ths
+# place methods.
+
+length = "practice"
+methods = [
+    { title = "Yorkshire Surprise Major",   lead_locations = { LE = 0, 2nds = 0 } },
+    { title = "Superlative Surprise Major", lead_locations = { LE = 0, 2nds = 0 } },
+    { title = "Bristol Surprise Major",     lead_locations = { LE = 0, 8ths = 0 } },
+    { title = "Deva Surprise Major",        lead_locations = { LE = 0, 8ths = 0 } },
+]
+
+base_calls = "none" # Only use our own custom calls
+[[calls]]
+symbol = ""
+debug_symbol = "-"
+place_notation = "14"
+lead_location = { from = "2nds", to = "LE" }
+
+[[calls]]
+symbol = "x"
+place_notation = "16"
+lead_location = { from = "8ths", to = "LE" }

--- a/monument/test/cases/call-from-to.toml
+++ b/monument/test/cases/call-from-to.toml
@@ -1,0 +1,25 @@
+# Like Leary's 23, these comps use `14` bobs only in 2nds place methods and `16` bobs only in 8ths
+# place methods.
+
+length = "QP"
+methods = [
+    { title = "Yorkshire Surprise Major",   lead_locations = { LE = 0, 2nds = 0 } },
+    { title = "Superlative Surprise Major", lead_locations = { LE = 0, 2nds = 0 } },
+    { title = "Bristol Surprise Major",     lead_locations = { LE = 0, 8ths = 0 } },
+    { title = "Deva Surprise Major",        lead_locations = { LE = 0, 8ths = 0 } },
+]
+method_count = { min = 224, max = 448 }
+
+part_head = "13456782"
+
+base_calls = "none" # Only use our own custom calls
+[[calls]]
+symbol = ""
+debug_symbol = "-"
+place_notation = "14"
+lead_location = { from = "2nds", to = "LE" }
+
+[[calls]]
+symbol = "x"
+place_notation = "16"
+lead_location = { from = "8ths", to = "LE" }

--- a/monument/test/cases/error-messages.md
+++ b/monument/test/cases/error-messages.md
@@ -85,18 +85,6 @@ method = "Corwnall Surprise major" # TODO: Maybe we shouldn't display a diff for
 
 
 
-## misc-method-parsing
-
-### non-integer-lead-index
-```toml
-length = "QP"
-[method]
-title = "Bristol Surprise Royal"
-lead_locations = { X = "LE" } # 'X' isn't a valid integer
-```
-
-
-
 ## no-methods
 ```toml
 length = "QP"
@@ -276,7 +264,7 @@ on the half-lead:
 ```toml
 length = "practice"
 method.title = "Bristol Surprise Major"
-method.lead_locations = { 0 = "LE", 16 = "HL" }
+method.lead_locations = { LE = 0, HL = 16 }
 default_music = false
 
 [[calls]]

--- a/monument/test/cases/hl-calls.toml
+++ b/monument/test/cases/hl-calls.toml
@@ -1,6 +1,6 @@
 length = { min = 0, max = 200 }
 method.title = "Bristol Surprise Major"
-method.lead_locations = { 0 = "LE", 16 = "HL" }
+method.lead_locations = { LE = 0, HL = 16 }
 default_music = false
 
 # music_file = "music-8.toml"

--- a/monument/test/results.json
+++ b/monument/test/results.json
@@ -3420,5 +3420,119 @@
       { "length": 224, "string": "CYCYCYC", "avg_score": 0.026785715 },
       { "length": 224, "string": "YCYCYCY", "avg_score": 0.026785715 }
     ]
+  },
+  "test/error-messages.md: ambiguous-course-heads": {
+    "error_message": "The same course could be given two different course heads:\n     1x5x6x78, satisfying 1xxxxx78\n  or 1xx8x756, satisfying 1xxxxx56"
+  },
+  "test/error-messages.md: bobs-and-singles-only": {
+    "error_message": "Can't be both `bobs_only` and `singles_only`"
+  },
+  "test/error-messages.md: call-pn-parse": {
+    "error_message": "Can't parse place notation \"10\" for call \"x\": Place '0' is out of stage Major"
+  },
+  "test/error-messages.md: calling-positions-too-short": {
+    "error_message": "Call \"x\" only specifies 7 calling positions, but the stage is Major"
+  },
+  "test/error-messages.md: ch-mask::bell-out-of-stage": {
+    "error_message": "Can't parse course head mask \"1234*9\": bell 9 is out of stage Major"
+  },
+  "test/error-messages.md: ch-mask::too-long": {
+    "error_message": "Can't parse course head mask \"1234x5678\": mask is too long, needing at least 9 bells (too many for Major)"
+  },
+  "test/error-messages.md: ch-mask::too-many-*s": {
+    "error_message": "Can't parse course head mask \"1*2*3\": too many `*`s.  Masks can only have one region with `x` or `*`."
+  },
+  "test/error-messages.md: ch-mask::too-short": {
+    "error_message": "Can't parse course head mask \"12345\": mask is too short; did you mean `12345*` or `12345678`?"
+  },
+  "test/error-messages.md: ch-pattern::bell-out-of-stage": {
+    "error_message": "Can't parse course head weight \"x9*\": bell 9 is out of stage Major"
+  },
+  "test/error-messages.md: ch-pattern::too-long": {
+    "error_message": "Can't parse course head weight \"1234*5678x\": mask is too long, needing at least 9 bells (too many for Major)"
+  },
+  "test/error-messages.md: ch-pattern::too-many-*s": {
+    "error_message": "Can't parse course head weight \"*7*8\": too many `*`s.  Masks can only have one region with `x` or `*`."
+  },
+  "test/error-messages.md: ch-pattern::too-short": {
+    "error_message": "Can't parse course head weight \"12345\": mask is too short; did you mean `12345*` or `12345678`?"
+  },
+  "test/error-messages.md: duplicate-calls::debug-symbol": {
+    "error_message": "Call debug symbol \"-\" (at \"LE\") is used for both 14 and 16"
+  },
+  "test/error-messages.md: duplicate-calls::different-lead-locations": {
+    "comps": [
+      { "length": 64, "string": "sHsH", "avg_score": -0.071875 },
+      { "length": 128, "string": "HsHHsH", "avg_score": -0.0640625 },
+      { "length": 128, "string": "sHHsHH", "avg_score": -0.0640625 },
+      { "length": 192, "string": "HHsHHHsH", "avg_score": -0.061458334 },
+      { "length": 192, "string": "HsHHHsHH", "avg_score": -0.061458334 },
+      { "length": 192, "string": "sHHHsHHH", "avg_score": -0.061458334 },
+      { "length": 96, "string": "HHH", "avg_score": -0.056249995 },
+      { "length": 288, "string": "MBW", "avg_score": -0.018749999 },
+      { "length": 288, "string": "sHsh", "avg_score": -0.018402778 },
+      { "length": 288, "string": "sMsm", "avg_score": -0.018402778 },
+      { "length": 288, "string": "shsH", "avg_score": -0.018402778 },
+      { "length": 288, "string": "swsW", "avg_score": -0.018402778 },
+      { "length": 224, "string": "", "avg_score": 0.0 }
+    ]
+  },
+  "test/error-messages.md: duplicate-calls::display-symbol": {
+    "error_message": "Call display symbol \"s\" (at \"LE\") is used for both 1234 and 1678"
+  },
+  "test/error-messages.md: duplicate-calls::same-pn": {
+    "comps": [
+      { "length": 64, "string": "sHsH", "avg_score": -0.09375 },
+      { "length": 128, "string": "HsHHsH", "avg_score": -0.075 },
+      { "length": 128, "string": "sHHsHH", "avg_score": -0.075 },
+      { "length": 192, "string": "HHsHHHsH", "avg_score": -0.06875 },
+      { "length": 192, "string": "HsHHHsHH", "avg_score": -0.06875 },
+      { "length": 192, "string": "sHHHsHHH", "avg_score": -0.06875 },
+      { "length": 96, "string": "HHH", "avg_score": -0.056249995 },
+      { "length": 288, "string": "MBW", "avg_score": -0.018749999 },
+      { "length": 224, "string": "", "avg_score": 0.0 }
+    ]
+  },
+  "test/error-messages.md: duplicate-shorthand": {
+    "error_message": "Methods \"London Surprise Major\" and \"Lessness Surprise Major\" share a shorthand (L)"
+  },
+  "test/error-messages.md: method-not-found::case-1": {
+    "error_message": "Can't find \"Brisol Suprise Major\" in the Central Council method library.  Did you mean:\n     \"Bristol Surprise Major\" (Bristol Surprise Major)"
+  },
+  "test/error-messages.md: method-not-found::case-2": {
+    "error_message": "Can't find \"Camibridge Surprise Manor\" in the Central Council method library.  Did you mean:\n     \"Cambridge Surprise Major\" (Camibridge Surprise Manjor)\n  or \"Cambridge Surprise Minor\" (Camibridge Surprise Mainor)"
+  },
+  "test/error-messages.md: method-not-found::case-3": {
+    "error_message": "Can't find \"Corwnall Surprise major\" in the Central Council method library.  Did you mean:\n     \"Cornwall Surprise Major\" (Cornwnall Surprise mMajor)"
+  },
+  "test/error-messages.md: method-pn-parsing::ambiguous-gap": {
+    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x15x4.5x5.36.4x4.5x4x1,+8\"\n        ^^ Ambiguous gap of 3 bells between places '1' and '5'."
+  },
+  "test/error-messages.md: method-pn-parsing::bell-out-of-stage": {
+    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x5x4.5x5.36.4x4.5x4x1,+9\"\n                              ^ Place '9' is out of stage Major"
+  },
+  "test/error-messages.md: method-pn-parsing::misplaced-plus": {
+    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x5+4.5x5.36.4x4.5x4x1,+8\"\n         ^ `+` must only go at the start of a block (i.e. at the start or directly after a `,`)"
+  },
+  "test/error-messages.md: method-pn-parsing::odd-stage-cross": {
+    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x15x4.5x5.36.4x4.5x4x1,+8\"\n       ^ Cross notation isn't valid for odd stages (in this case Triples)"
+  },
+  "test/error-messages.md: method-pn-parsing::repeated-place": {
+    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x5x4.5x5.36.4x4.585x4x1,+9\"\n                       ^^^ Place '5' is duplicated"
+  },
+  "test/error-messages.md: no-methods": {
+    "error_message": "No methods specified.  Try e.g. `method = \"Bristol Surprise Major\"`."
+  },
+  "test/error-messages.md: part-head-parse::1": {
+    "error_message": "Can't parse part head \"13\": bell '2' is missing"
+  },
+  "test/error-messages.md: part-head-parse::2": {
+    "error_message": "Can't parse part head \"1321\": bell '1' appears twice."
+  },
+  "test/error-messages.md: part-head-parse::3": {
+    "error_message": "Can't parse part head \"123456789\": bell '9' is not within stage Major"
+  },
+  "test/error-messages.md: undefined-lead-location": {
+    "error_message": "Call \"x\" refers to a lead location \"poo\", which doesn't exist"
   }
 }

--- a/monument/test/results.json
+++ b/monument/test/results.json
@@ -86,6 +86,65 @@
       { "length": 1280, "string": "sWsMMBsHHsHsMsWsMHsHH", "avg_score": 0.12703124 }
     ]
   },
+  "test/cases/call-from-to-coursewise.toml": {
+    "comps": [
+      { "length": 256, "string": "YSS[M]YD[xI]B[xB]D[xH]B[xH]", "avg_score": 0.01953125 },
+      { "length": 256, "string": "YYS[M]SD[xI]B[xB]D[xH]B[xH]", "avg_score": 0.01953125 },
+      { "length": 256, "string": "SYS[M]YD[xI]B[xB]D[xH]B[xH]", "avg_score": 0.02734375 },
+      { "length": 256, "string": "YSY[M]SD[xI]B[xB]D[xH]B[xH]", "avg_score": 0.03515625 },
+      { "length": 256, "string": "SSY[M]YD[xI]B[xB]D[xH]B[xH]", "avg_score": 0.04296875 },
+      { "length": 256, "string": "SYY[M]SD[xI]B[xB]D[xH]B[xH]", "avg_score": 0.04296875 },
+      { "length": 256, "string": "B[xH]D[xB]B[xV]SSY[W]YD[xH]", "avg_score": 0.0625 },
+      { "length": 256, "string": "B[xH]D[xB]B[xV]SYS[W]YD[xH]", "avg_score": 0.0625 },
+      { "length": 256, "string": "B[xH]D[xB]B[xV]SYY[W]SD[xH]", "avg_score": 0.0625 },
+      { "length": 256, "string": "B[xH]D[xB]B[xV]YSS[W]YD[xH]", "avg_score": 0.07421875 },
+      { "length": 256, "string": "B[xH]D[xB]B[xV]YSY[W]SD[xH]", "avg_score": 0.07421875 },
+      { "length": 256, "string": "B[xH]D[xB]B[xV]YYS[W]SD[xH]", "avg_score": 0.07421875 },
+      { "length": 256, "string": "B[xH]SYS[M]YD[xI]B[xB]D[xH]", "avg_score": 0.07421875 },
+      { "length": 256, "string": "B[xH]SYY[M]SD[xI]B[xB]D[xH]", "avg_score": 0.07421875 },
+      { "length": 256, "string": "B[xH]YYS[M]SD[xI]B[xB]D[xH]", "avg_score": 0.08203125 },
+      { "length": 256, "string": "B[xH]SSY[M]YD[xI]B[xB]D[xH]", "avg_score": 0.0859375 },
+      { "length": 256, "string": "D[xB]B[xV]SYS[W]YD[xH]B[xH]", "avg_score": 0.08984375 },
+      { "length": 256, "string": "D[xB]B[xV]SYY[W]SD[xH]B[xH]", "avg_score": 0.08984375 },
+      { "length": 256, "string": "D[xB]B[xV]YYS[W]SD[xH]B[xH]", "avg_score": 0.08984375 },
+      { "length": 256, "string": "B[xH]YSS[M]YD[xI]B[xB]D[xH]", "avg_score": 0.09375 },
+      { "length": 256, "string": "B[xH]YSY[M]SD[xI]B[xB]D[xH]", "avg_score": 0.09375 },
+      { "length": 256, "string": "D[xB]B[xV]SSY[W]YD[xH]B[xH]", "avg_score": 0.09765625 },
+      { "length": 256, "string": "D[xB]B[xV]YSS[W]YD[xH]B[xH]", "avg_score": 0.09765625 },
+      { "length": 256, "string": "D[xB]B[xV]YSY[W]SD[xH]B[xH]", "avg_score": 0.09765625 },
+      { "length": 96, "string": "YS[B]D[xH]", "avg_score": 0.14583333 },
+      { "length": 96, "string": "YY[B]D[xH]", "avg_score": 0.14583333 },
+      { "length": 96, "string": "YDS", "avg_score": 0.15625 },
+      { "length": 96, "string": "SS[B]D[xH]", "avg_score": 0.16666667 },
+      { "length": 96, "string": "SY[B]D[xH]", "avg_score": 0.16666667 },
+      { "length": 96, "string": "SDS", "avg_score": 0.17708333 },
+      { "length": 96, "string": "YDY", "avg_score": 0.17708333 },
+      { "length": 96, "string": "SDY", "avg_score": 0.19791667 },
+      { "length": 96, "string": "D[xB]SY[H]", "avg_score": 0.22916667 },
+      { "length": 96, "string": "D[xB]YY[H]", "avg_score": 0.22916667 },
+      { "length": 96, "string": "YSD", "avg_score": 0.22916667 },
+      { "length": 96, "string": "YYD", "avg_score": 0.22916667 },
+      { "length": 96, "string": "SSD", "avg_score": 0.25 },
+      { "length": 96, "string": "SYD", "avg_score": 0.25 },
+      { "length": 96, "string": "D[xB]SS[H]", "avg_score": 0.26041666 },
+      { "length": 96, "string": "D[xB]YS[H]", "avg_score": 0.26041666 },
+      { "length": 96, "string": "DSS", "avg_score": 0.38541666 },
+      { "length": 96, "string": "DYS", "avg_score": 0.38541666 },
+      { "length": 96, "string": "DSY", "avg_score": 0.40625 },
+      { "length": 96, "string": "DYY", "avg_score": 0.40625 }
+    ]
+  },
+  "test/cases/call-from-to.toml": {
+    "comps": [
+      { "length": 1344, "string": "#B[x]DD[x]B[x]SY[-]", "avg_score": 0.023809524, "part_head": "17823456" },
+      { "length": 1344, "string": "#D[x]S[-]BY[-]BD", "avg_score": 0.025967263, "part_head": "14567823" },
+      { "length": 1344, "string": "#D[x]B[x]S[-]YS[-]D", "avg_score": 0.027455358, "part_head": "17823456" },
+      { "length": 1344, "string": "#D[x]Y[-]BS[-]BD", "avg_score": 0.02827381, "part_head": "14567823" },
+      { "length": 1344, "string": "#D[x]B[x]S[-]YY[-]D", "avg_score": 0.029017856, "part_head": "17823456" },
+      { "length": 1344, "string": "#D[x]B[x]S[-]SY[-]D", "avg_score": 0.029687501, "part_head": "17823456" },
+      { "length": 1344, "string": "#B[x]DD[x]B[x]YS[-]", "avg_score": 0.036458332, "part_head": "17823456" }
+    ]
+  },
   "test/cases/custom-method-count-1.toml": {
     "comps": [
       { "length": 224, "string": "CCCCCCC", "avg_score": 0.0 },
@@ -1332,9 +1391,6 @@
   },
   "test/cases/error-messages.md: method-pn-parsing::repeated-place": {
     "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x5x4.5x5.36.4x4.585x4x1,+9\"\n                       ^^^ Place '5' is duplicated"
-  },
-  "test/cases/error-messages.md: misc-method-parsing::non-integer-lead-index": {
-    "error_message": "Lead location \"X\" (for label \"LE\" in \"Bristol Surprise Royal\") is not a valid integer"
   },
   "test/cases/error-messages.md: no-methods": {
     "error_message": "No methods specified.  Try e.g. `method = \"Bristol Surprise Major\"`."
@@ -3420,119 +3476,5 @@
       { "length": 224, "string": "CYCYCYC", "avg_score": 0.026785715 },
       { "length": 224, "string": "YCYCYCY", "avg_score": 0.026785715 }
     ]
-  },
-  "test/error-messages.md: ambiguous-course-heads": {
-    "error_message": "The same course could be given two different course heads:\n     1x5x6x78, satisfying 1xxxxx78\n  or 1xx8x756, satisfying 1xxxxx56"
-  },
-  "test/error-messages.md: bobs-and-singles-only": {
-    "error_message": "Can't be both `bobs_only` and `singles_only`"
-  },
-  "test/error-messages.md: call-pn-parse": {
-    "error_message": "Can't parse place notation \"10\" for call \"x\": Place '0' is out of stage Major"
-  },
-  "test/error-messages.md: calling-positions-too-short": {
-    "error_message": "Call \"x\" only specifies 7 calling positions, but the stage is Major"
-  },
-  "test/error-messages.md: ch-mask::bell-out-of-stage": {
-    "error_message": "Can't parse course head mask \"1234*9\": bell 9 is out of stage Major"
-  },
-  "test/error-messages.md: ch-mask::too-long": {
-    "error_message": "Can't parse course head mask \"1234x5678\": mask is too long, needing at least 9 bells (too many for Major)"
-  },
-  "test/error-messages.md: ch-mask::too-many-*s": {
-    "error_message": "Can't parse course head mask \"1*2*3\": too many `*`s.  Masks can only have one region with `x` or `*`."
-  },
-  "test/error-messages.md: ch-mask::too-short": {
-    "error_message": "Can't parse course head mask \"12345\": mask is too short; did you mean `12345*` or `12345678`?"
-  },
-  "test/error-messages.md: ch-pattern::bell-out-of-stage": {
-    "error_message": "Can't parse course head weight \"x9*\": bell 9 is out of stage Major"
-  },
-  "test/error-messages.md: ch-pattern::too-long": {
-    "error_message": "Can't parse course head weight \"1234*5678x\": mask is too long, needing at least 9 bells (too many for Major)"
-  },
-  "test/error-messages.md: ch-pattern::too-many-*s": {
-    "error_message": "Can't parse course head weight \"*7*8\": too many `*`s.  Masks can only have one region with `x` or `*`."
-  },
-  "test/error-messages.md: ch-pattern::too-short": {
-    "error_message": "Can't parse course head weight \"12345\": mask is too short; did you mean `12345*` or `12345678`?"
-  },
-  "test/error-messages.md: duplicate-calls::debug-symbol": {
-    "error_message": "Call debug symbol \"-\" (at \"LE\") is used for both 14 and 16"
-  },
-  "test/error-messages.md: duplicate-calls::different-lead-locations": {
-    "comps": [
-      { "length": 64, "string": "sHsH", "avg_score": -0.071875 },
-      { "length": 128, "string": "HsHHsH", "avg_score": -0.0640625 },
-      { "length": 128, "string": "sHHsHH", "avg_score": -0.0640625 },
-      { "length": 192, "string": "HHsHHHsH", "avg_score": -0.061458334 },
-      { "length": 192, "string": "HsHHHsHH", "avg_score": -0.061458334 },
-      { "length": 192, "string": "sHHHsHHH", "avg_score": -0.061458334 },
-      { "length": 96, "string": "HHH", "avg_score": -0.056249995 },
-      { "length": 288, "string": "MBW", "avg_score": -0.018749999 },
-      { "length": 288, "string": "sHsh", "avg_score": -0.018402778 },
-      { "length": 288, "string": "sMsm", "avg_score": -0.018402778 },
-      { "length": 288, "string": "shsH", "avg_score": -0.018402778 },
-      { "length": 288, "string": "swsW", "avg_score": -0.018402778 },
-      { "length": 224, "string": "", "avg_score": 0.0 }
-    ]
-  },
-  "test/error-messages.md: duplicate-calls::display-symbol": {
-    "error_message": "Call display symbol \"s\" (at \"LE\") is used for both 1234 and 1678"
-  },
-  "test/error-messages.md: duplicate-calls::same-pn": {
-    "comps": [
-      { "length": 64, "string": "sHsH", "avg_score": -0.09375 },
-      { "length": 128, "string": "HsHHsH", "avg_score": -0.075 },
-      { "length": 128, "string": "sHHsHH", "avg_score": -0.075 },
-      { "length": 192, "string": "HHsHHHsH", "avg_score": -0.06875 },
-      { "length": 192, "string": "HsHHHsHH", "avg_score": -0.06875 },
-      { "length": 192, "string": "sHHHsHHH", "avg_score": -0.06875 },
-      { "length": 96, "string": "HHH", "avg_score": -0.056249995 },
-      { "length": 288, "string": "MBW", "avg_score": -0.018749999 },
-      { "length": 224, "string": "", "avg_score": 0.0 }
-    ]
-  },
-  "test/error-messages.md: duplicate-shorthand": {
-    "error_message": "Methods \"London Surprise Major\" and \"Lessness Surprise Major\" share a shorthand (L)"
-  },
-  "test/error-messages.md: method-not-found::case-1": {
-    "error_message": "Can't find \"Brisol Suprise Major\" in the Central Council method library.  Did you mean:\n     \"Bristol Surprise Major\" (Bristol Surprise Major)"
-  },
-  "test/error-messages.md: method-not-found::case-2": {
-    "error_message": "Can't find \"Camibridge Surprise Manor\" in the Central Council method library.  Did you mean:\n     \"Cambridge Surprise Major\" (Camibridge Surprise Manjor)\n  or \"Cambridge Surprise Minor\" (Camibridge Surprise Mainor)"
-  },
-  "test/error-messages.md: method-not-found::case-3": {
-    "error_message": "Can't find \"Corwnall Surprise major\" in the Central Council method library.  Did you mean:\n     \"Cornwall Surprise Major\" (Cornwnall Surprise mMajor)"
-  },
-  "test/error-messages.md: method-pn-parsing::ambiguous-gap": {
-    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x15x4.5x5.36.4x4.5x4x1,+8\"\n        ^^ Ambiguous gap of 3 bells between places '1' and '5'."
-  },
-  "test/error-messages.md: method-pn-parsing::bell-out-of-stage": {
-    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x5x4.5x5.36.4x4.5x4x1,+9\"\n                              ^ Place '9' is out of stage Major"
-  },
-  "test/error-messages.md: method-pn-parsing::misplaced-plus": {
-    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x5+4.5x5.36.4x4.5x4x1,+8\"\n         ^ `+` must only go at the start of a block (i.e. at the start or directly after a `,`)"
-  },
-  "test/error-messages.md: method-pn-parsing::odd-stage-cross": {
-    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x15x4.5x5.36.4x4.5x4x1,+8\"\n       ^ Cross notation isn't valid for odd stages (in this case Triples)"
-  },
-  "test/error-messages.md: method-pn-parsing::repeated-place": {
-    "error_message": "Can't parse place notation for method \"Bristol\":\n     \"&x5x4.5x5.36.4x4.585x4x1,+9\"\n                       ^^^ Place '5' is duplicated"
-  },
-  "test/error-messages.md: no-methods": {
-    "error_message": "No methods specified.  Try e.g. `method = \"Bristol Surprise Major\"`."
-  },
-  "test/error-messages.md: part-head-parse::1": {
-    "error_message": "Can't parse part head \"13\": bell '2' is missing"
-  },
-  "test/error-messages.md: part-head-parse::2": {
-    "error_message": "Can't parse part head \"1321\": bell '1' appears twice."
-  },
-  "test/error-messages.md: part-head-parse::3": {
-    "error_message": "Can't parse part head \"123456789\": bell '9' is not within stage Major"
-  },
-  "test/error-messages.md: undefined-lead-location": {
-    "error_message": "Call \"x\" refers to a lead location \"poo\", which doesn't exist"
   }
 }


### PR DESCRIPTION
This adds two extra features to lead locations:
1. The same row can be labelled with multiple labels
2. Calls can now go from/to different lead labels

Between them, these allow for very fine-grained control over when calls can be placed.  For example, things like [Leary's 23](https://complib.org/composition/21607) (2nds/8ths place methods have 4ths/6ths place bobs, respectively) or forcing only plain leads of particular methods (useful if you include a LE-variant of a common method in spliced).