### PR TITLE
Replace `default_music` with `base_music`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## (Unreleased)
 
 ### Monument
+- (#94) Replace `default_music` with `base_music` (to be consistent with `base_calls`).
 - (#92) Print music as part of the composition summary.
 - (#92) Remove fixed tenors from part heads (e.g. `1342567890ET` is now be just `1342`).
 - (#91) Calls can now go from/to different lead labels.  Set this with e.g.

--- a/monument/cli/guide.md
+++ b/monument/cli/guide.md
@@ -174,7 +174,8 @@ take you to more in-depth docs about it.
 - [`calls = []`](#calls-2)
 
 **Music:**
-- [`default_music = true`](#default_music) _(since v0.8.0)_
+- ~[`default_music = true`](#default_music)~ _(since v0.8.0, replaced by `base_music` in v0.9.0)_
+- [`base_music = "default"`](#base_music) _(since v0.9.0)_
 - [`music_file`](#music_file) (optional)
 - [`music = []`](#music-2)
 - [`start_stroke = "back"`](#start_stroke)
@@ -379,17 +380,29 @@ be spliced over a call).
 
 ### Music
 
-#### `default_music` _(since v0.8.0)_
+#### `default_music` _(since v0.8.0, replaced by `base_music` in v0.9.0)_
 
-If set to `true`, then a 'default' music profile is used if no custom music is specified.  **NOTE:**
-this defaults to `true`, so you have to explicitly set it to false.  The default music profiles are
-equivalent to importing the following music files:
+See `base_music`:
+- `default_music = false` is equivalent to `base_music = "none"`
+- `default_music = true` is equivalent to `base_music = "default"`
 
-- [Minor](src/default-music-minor.toml)
-- [Triples](src/default-music-triples.toml)
-- [Major](src/default-music-major.toml)
-- [Royal](src/default-music-royal.toml)
-- [Maximus](src/default-music-maximus.toml)
+#### `base_music`
+
+Like [`base_calls`](#base_calls), `base_music` adds a set of basic music definitions to the search.
+`base_music` has two values, the default being `base_music = "default"`:
+
+1. `base_music = "none"`:  Adds no music to the search; the only music will be what you explicitly
+   specify.
+2. `base_music = "default"`:  For most stages, this adds a basic music profile intended to be a sane
+   default for most music tastes.  This roughly follows the 'headline' music in CompLib (i.e. the
+   summary line shown below every composition.
+
+   The default music profiles are equivalent to importing the following music files:
+   - [Minor](src/default-music-minor.toml)
+   - [Triples](src/default-music-triples.toml)
+   - [Major](src/default-music-major.toml)
+   - [Royal](src/default-music-royal.toml)
+   - [Maximus](src/default-music-maximus.toml)
 
 #### `music_file`
 
@@ -412,6 +425,11 @@ weight = 2    # Score applied per instance of this music type.  Optional; defaul
 count = { min = 12, max = 24 } # Overall required count range
 stroke = "back" # On which stroke(s) to count this music.
                 # Options: "both" (default), "back", "hand".
+show = true # If `true`, display this music in the composition summary.
+            # Optional; defaults to `true`
+name = "87s at back" # If `show = true`, sets a custom name used in the summary output.
+                     # By default, Monument will decide how to display music (often combining
+                     # separate patterns together)
 ```
 
 #### `start_stroke`

--- a/monument/cli/src/calls.rs
+++ b/monument/cli/src/calls.rs
@@ -1,10 +1,11 @@
 use bellframe::{method::LABEL_LEAD_END, PlaceNot, Stage};
 use itertools::Itertools;
 use monument::layout::new::{default_calling_positions, Call};
-use serde::{de, Deserialize, Deserializer};
+use serde::Deserialize;
 
 /// The values of the `base_calls` attribute
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum BaseCalls {
     None,
     Near,
@@ -71,22 +72,6 @@ impl BaseCalls {
 impl Default for BaseCalls {
     fn default() -> Self {
         Self::Near
-    }
-}
-
-impl<'de> Deserialize<'de> for BaseCalls {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        let lower_str = s.to_lowercase();
-        Ok(match lower_str.as_str() {
-            "none" => BaseCalls::None,
-            "near" => BaseCalls::Near,
-            "far" => BaseCalls::Far,
-            _ => return Err(de::Error::custom(format!("unknown call type '{}'", s))),
-        })
     }
 }
 

--- a/monument/test/cases/87s-at-back.toml
+++ b/monument/test/cases/87s-at-back.toml
@@ -4,6 +4,7 @@ length = "practice"
 method = "Plain Bob Major"
 course_heads = ["12345xxx"]
 base_calls = "far"
+base_music = "none" # Only count 87s as score
 
 [[music]]
 pattern = "*87"

--- a/monument/test/cases/bobs-only.toml
+++ b/monument/test/cases/bobs-only.toml
@@ -1,4 +1,4 @@
 length = "practice"
 method = "Plain Bob Major"
 bobs_only = true
-default_music = false
+base_music = "none"

--- a/monument/test/cases/bristol-s8-qps.toml
+++ b/monument/test/cases/bristol-s8-qps.toml
@@ -2,6 +2,8 @@ length = { min = 1250, max = 1280 }
 num_comps = 50
 method = "Bristol Surprise Major"
 
+base_music = "none"
+
 [[music]]
 run_lengths = [4, 5, 6, 7]
 

--- a/monument/test/cases/custom-method-count-1.toml
+++ b/monument/test/cases/custom-method-count-1.toml
@@ -1,9 +1,9 @@
 length = "practice"
+num_comps = 150 # 120 Comps are generated
 methods = [
     "Yorkshire Surprise Major",
     { title = "Cambridge Surprise Major", count.min = 64 }, # Require >=2 leads of Cambs
 ]
 method_count = { min = 0, max = 224 }
 base_calls = "none"
-num_comps = 150 # 120 Comps are generated
-default_music = false
+base_music = "none"

--- a/monument/test/cases/custom-method-count-2.toml
+++ b/monument/test/cases/custom-method-count-2.toml
@@ -5,4 +5,4 @@ methods = [
 ]
 method_count = { min = 0, max = 224 }
 base_calls = "none"
-default_music = false
+base_music = "none"

--- a/monument/test/cases/custom-method-count-3.toml
+++ b/monument/test/cases/custom-method-count-3.toml
@@ -5,4 +5,4 @@ methods = [
 ]
 method_count = { min = 0, max = 224 }
 base_calls = "none"
-default_music = false
+base_music = "none"

--- a/monument/test/cases/cyclic-callwise.toml
+++ b/monument/test/cases/cyclic-callwise.toml
@@ -1,8 +1,10 @@
 length = "QP"
 methods = ["Little Bob Major", "Plain Bob Major"]
-music_file = "../music/8.toml"
 splice_style = "calls"
 part_head = "18234567"
 method_count = { min = 400, max = 800 }
 bob_weight = -6
 single_weight = -8
+
+base_music = "none"
+music_file = "../music/8.toml"

--- a/monument/test/cases/cyclic-no-calls.toml
+++ b/monument/test/cases/cyclic-no-calls.toml
@@ -9,5 +9,6 @@ methods = [
 part_head = "13456782"
 method_count = { min = 0, max = 500 }
 
+base_music = "none"
 [[music]]
 run_lengths = [4, 5, 6, 7, 8]

--- a/monument/test/cases/error-messages.md
+++ b/monument/test/cases/error-messages.md
@@ -249,7 +249,7 @@ This doesn't actually produce an error message, because there are two definition
 ```toml
 length = "practice"
 method = "Bristol Surprise Major"
-default_music = false
+base_music = "none"
 
 [[calls]]
 symbol = "s" # Not a clash, because this is an identical definition
@@ -265,7 +265,7 @@ on the half-lead:
 length = "practice"
 method.title = "Bristol Surprise Major"
 method.lead_locations = { LE = 0, HL = 16 }
-default_music = false
+base_music = "none"
 
 [[calls]]
 symbol = "s" # Not a clash, because this is a HL call

--- a/monument/test/cases/exact-count.toml
+++ b/monument/test/cases/exact-count.toml
@@ -1,4 +1,6 @@
 length = 224
 method = "Bristol Surprise Major"
-music_file = "../music/8.toml"
 method_count = 224
+
+base_music = "none"
+music_file = "../music/8.toml"

--- a/monument/test/cases/false-course-2.toml
+++ b/monument/test/cases/false-course-2.toml
@@ -1,4 +1,4 @@
 # This attempts to break the optimisation passes by having a small number of very false chunks
 length = "practice"
 method = "Normandy Surprise Major"
-default_music = false
+base_music = "none"

--- a/monument/test/cases/false-course-3.toml
+++ b/monument/test/cases/false-course-3.toml
@@ -2,7 +2,7 @@
 length = "practice"
 method = "Normandy Surprise Major"
 split_tenors = true
-default_music = false
+base_music = "none"
 
 base_calls = "none"
 [[calls]]

--- a/monument/test/cases/false-splice.toml
+++ b/monument/test/cases/false-splice.toml
@@ -3,5 +3,7 @@
 length = "practice"
 num_comps = 400 # 328 comps are possible, so asking for 400 requires Monument generate them all
 methods = ["Bristol Surprise Major", "Lancashire Surprise Major"]
-music_file = "../music/8.toml"
 method_count = { min = 0, max = 500 } # Allow any combination of methods
+
+base_music = "none"
+music_file = "../music/8.toml"

--- a/monument/test/cases/false.toml
+++ b/monument/test/cases/false.toml
@@ -1,5 +1,7 @@
 length = "practice"
 methods = ["Bristol Surprise Major", "Yorkshire Surprise Major"]
-music_file = "../music/8.toml"
 base_calls = "none"
 allow_false = true
+
+base_music = "none"
+music_file = "../music/8.toml"

--- a/monument/test/cases/handbell-2.toml
+++ b/monument/test/cases/handbell-2.toml
@@ -6,7 +6,7 @@ num_comps = 500 # 453 comps are possible, so asking for 500 will force Monument 
                 # consistent output
 method = "Plain Bob Major"
 split_tenors = true
-default_music = false
+base_music = "none"
 
 bob_weight = -4
 single_weight = -7

--- a/monument/test/cases/handbell.toml
+++ b/monument/test/cases/handbell.toml
@@ -7,7 +7,7 @@ num_comps = 500 # 453 comps are possible, so asking for 500 will force Monument 
 method = "Plain Bob Major"
 split_tenors = true
 
-default_music = false
+base_music = "none"
 
 bob_weight = -4
 single_weight = -7

--- a/monument/test/cases/hl-calls.toml
+++ b/monument/test/cases/hl-calls.toml
@@ -1,9 +1,7 @@
 length = { min = 0, max = 200 }
 method.title = "Bristol Surprise Major"
 method.lead_locations = { LE = 0, HL = 16 }
-default_music = false
-
-# music_file = "music-8.toml"
+base_music = "none"
 
 [[calls]]
 place_notation = "58"

--- a/monument/test/cases/implicit-leadwise.toml
+++ b/monument/test/cases/implicit-leadwise.toml
@@ -1,4 +1,6 @@
 length = { min = 0, max = 500 }
 methods = ["Plain Bob Major", "Little Bob Major"]
 part_head = "13456782"
+
+base_music = "none"
 music_file = "../music/8.toml"

--- a/monument/test/cases/inclusive-method-count.toml
+++ b/monument/test/cases/inclusive-method-count.toml
@@ -4,5 +4,7 @@
 
 length = 224
 method = "Bristol Surprise Major"
-music_file = "../music/8.toml"
 method_count = { min = 224, max = 224 }
+
+base_music = "none"
+music_file = "../music/8.toml"

--- a/monument/test/cases/leadwise-no-calls.toml
+++ b/monument/test/cases/leadwise-no-calls.toml
@@ -8,5 +8,6 @@ methods = [
 leadwise = true
 method_count = { min = 0, max = 500 }
 
+base_music = "none"
 [[music]]
 run_lengths = [4, 5, 6, 7, 8]

--- a/monument/test/cases/little-bob-shorthand.toml
+++ b/monument/test/cases/little-bob-shorthand.toml
@@ -5,4 +5,6 @@
 length = "practice"
 methods = ["Plain Bob Major", "Little Bob Major"]
 base_calls = "none"
+
+base_music = "none"
 music_file = "../music/8.toml"

--- a/monument/test/cases/multipart-2.toml
+++ b/monument/test/cases/multipart-2.toml
@@ -1,5 +1,7 @@
 length = { min = 0, max = 2000 }
 method = "Yorkshire Surprise Major"
-music_file = "../music/8.toml"
 part_head = "1423"
 course_heads = ["*678"]
+
+base_music = "none"
+music_file = "../music/8.toml"

--- a/monument/test/cases/multipart-ch-weight.toml
+++ b/monument/test/cases/multipart-ch-weight.toml
@@ -5,7 +5,7 @@
 length = "practice"
 methods = ["Bristol Surprise Major"]
 part_head = "1243"
-default_music = false
+base_music = "none"
 
 bob_weight = 0
 single_weight = 0

--- a/monument/test/cases/multipart-far-calls.toml
+++ b/monument/test/cases/multipart-far-calls.toml
@@ -3,5 +3,7 @@
 length = { min = 0, max = 2000 }
 base_calls = "far"
 method = "Bristol Surprise Royal"
-music_file = "../music/10.toml"
 part_head = "14523"
+
+base_music = "none"
+music_file = "../music/10.toml"

--- a/monument/test/cases/multipart.toml
+++ b/monument/test/cases/multipart.toml
@@ -1,5 +1,7 @@
 length = "practice"
 method = "Bristol Surprise Major"
-music_file = "../music/8.toml"
 part_head = "1243"
 course_heads = ["xxxx5678"]
+
+base_music = "none"
+music_file = "../music/8.toml"

--- a/monument/test/cases/negative-start-index-2.toml
+++ b/monument/test/cases/negative-start-index-2.toml
@@ -1,9 +1,11 @@
 length = { min = 0, max = 500 }
 method = "Birthday Delight Major"
-music_file = "../music/8.toml"
 start_indices = [-4]
 end_indices = [0, 2]
 course_heads = ["24315678", "1*78"]
+
+base_music = "none"
+music_file = "../music/8.toml"
 
 bob_weight = -6
 single_weight = -10

--- a/monument/test/cases/negative-start-index.toml
+++ b/monument/test/cases/negative-start-index.toml
@@ -1,8 +1,10 @@
 length = { min = 0, max = 500 }
 method = "Birthday Delight Major"
-music_file = "../music/8.toml"
 start_indices = [-4]
 course_heads = ["24315678", "1*78"]
+
+base_music = "none"
+music_file = "../music/8.toml"
 
 bob_weight = -6
 single_weight = -10

--- a/monument/test/cases/no-87s-at-back.toml
+++ b/monument/test/cases/no-87s-at-back.toml
@@ -5,6 +5,7 @@ method = "Plain Bob Major"
 course_heads = ["12345xxx"]
 base_calls = "far"
 
+base_music = "none"
 [[music]]
 pattern = "*87"
 stroke = "back"

--- a/monument/test/cases/no-calls.toml
+++ b/monument/test/cases/no-calls.toml
@@ -7,4 +7,6 @@ methods = [
 ]
 splice_style = "leads"
 method_count = { min = 0, max = 300 }
+
+base_music = "none"
 music_file = "../music/8.toml"

--- a/monument/test/cases/no-links.toml
+++ b/monument/test/cases/no-links.toml
@@ -6,4 +6,6 @@ methods = [
 ]
 splice_style = "calls"
 method_count.max = 400
+
+base_music = "none"
 music_file = "../music/8.toml"

--- a/monument/test/cases/per-method-chs.toml
+++ b/monument/test/cases/per-method-chs.toml
@@ -5,4 +5,4 @@ methods = [
     { title = "Bristol Surprise Major", course_heads = ["12345678"] }
 ]
 method_count = { min = 0, max = 400 }
-default_music = false
+base_music = "none"

--- a/monument/test/cases/per-method-start-ends-2.toml
+++ b/monument/test/cases/per-method-start-ends-2.toml
@@ -6,4 +6,4 @@ methods = [
 end_indices = [2] # Force Yorkshire to finish at the snap
 course_heads = ["*5678"] # Don't allow snaps in Bristol (because that'd require `*5x678`)
 method_count = { min = 0, max = 400 }
-default_music = false
+base_music = "none"

--- a/monument/test/cases/per-method-start-ends-3.toml
+++ b/monument/test/cases/per-method-start-ends-3.toml
@@ -6,4 +6,4 @@ methods = [
 end_indices = [2] # Force Yorkshire to finish at the snap
 course_heads = ["*5678", "*5x678"] # `*5x678` needed to allow snap starts/finishes in Bristol
 method_count = { min = 0, max = 400 }
-default_music = false
+base_music = "none"

--- a/monument/test/cases/per-method-start-ends.toml
+++ b/monument/test/cases/per-method-start-ends.toml
@@ -6,4 +6,4 @@ methods = [
     { title = "Bristol Surprise Major", start_indices = [0, 2], end_indices = [0, 2] }
 ]
 method_count = { min = 0, max = 400 }
-default_music = false
+base_music = "none"

--- a/monument/test/cases/plain-splice-over-part-head-2.toml
+++ b/monument/test/cases/plain-splice-over-part-head-2.toml
@@ -3,7 +3,7 @@
 length = { min = 0, max = 800 }
 part_head = "1342"
 course_heads = ["*5678"]
-default_music = false
+base_music = "none"
 
 methods = [
     "Deva Surprise Major",

--- a/monument/test/cases/plain-splice-over-part-head.toml
+++ b/monument/test/cases/plain-splice-over-part-head.toml
@@ -3,13 +3,14 @@
 length = { min = 0, max = 800 }
 part_head = "1342"
 course_heads = ["*5678"]
-default_music = false
 
 methods = ["Deva Surprise Major", "Ytterbium Surprise Major"]
 method_count = { min = 0, max = 800 }
 splice_style = "calls"
-splice_weight = 1
 
+# Only count method splices
+splice_weight = 1
+base_music = "none"
 bob_weight = 0
 single_weight = 0
 

--- a/monument/test/cases/self-false-1.toml
+++ b/monument/test/cases/self-false-1.toml
@@ -5,5 +5,7 @@ methods = [
     "Bristol Surprise Major",
     { name = "Ummm", place_notation = "xxx1x4,8", stage = 8 }, # Each lead is false against itself
 ]
-music_file = "../music/8.toml"
 method_count = { min = 0, max = 500 } # Allow not using any Ummm
+
+base_music = "none"
+music_file = "../music/8.toml"

--- a/monument/test/cases/self-false-2.toml
+++ b/monument/test/cases/self-false-2.toml
@@ -5,4 +5,6 @@ methods = [
     "Bristol Surprise Major",
     { name = "Ummm", place_notation = "x1xxx4,8", stage = 8 }, # Each lead is false against itself
 ]
+
+base_music = "none"
 music_file = "../music/8.toml"

--- a/monument/test/cases/singles-only.toml
+++ b/monument/test/cases/singles-only.toml
@@ -1,4 +1,4 @@
 length = "practice"
 method = "Plain Bob Major"
 singles_only = true
-default_music = false
+base_music = "none"

--- a/monument/test/cases/splice-over-part-head.toml
+++ b/monument/test/cases/splice-over-part-head.toml
@@ -6,9 +6,9 @@ course_heads = ["*5678"]
 
 methods = ["Yorkshire Surprise Major", "Cornwall Surprise Major"]
 method_count = { min = 0, max = 800 }
+
+# We want the only score to be the splices
 splice_weight = 1
-
-default_music = false
-
+base_music = "none"
 bob_weight = 0
 single_weight = 0

--- a/monument/test/cases/splice-weight-1.toml
+++ b/monument/test/cases/splice-weight-1.toml
@@ -2,7 +2,7 @@ length = "practice"
 base_calls = "none"
 num_comps = 200
 leadwise = true # Check that this still works for leadwise
-default_music = false
+base_music = "none"
 
 methods = [
     "Cambridge Surprise Major",

--- a/monument/test/cases/splice-weight-2.toml
+++ b/monument/test/cases/splice-weight-2.toml
@@ -1,7 +1,7 @@
 length = "practice"
-base_calls = "none"
 num_comps = 200
-default_music = false
+base_calls = "none"
+base_music = "none"
 
 methods = [
     "Cambridge Surprise Major",


### PR DESCRIPTION
This makes 'default' music consistent with the 'default' calls, as well as allowing the user to add custom music to the default.  In the future, this allows adding different base profiles (e.g. CompLib's music scoring).