### PR TITLE
Suggest `{bob,single}s_only` if given a very small `{single,bob}_weight`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## (Unreleased)
 
 ### Monument
+- (#95) Suggest using `{bob,single}s_only = true` if `{single,bob}_weight` is set to a large
+    negative value.  `{bob,single}s_only` is faster than using `{single,bob}_weight`, but sometimes
+    both call types are _required_ to bring a composition round with the right length so Monument
+    can't automatically set `{bob,single}s_only`.
 - (#94) Replace `default_music` with `base_music` (to be consistent with `base_calls`).
 - (#92) Print music as part of the composition summary.
 - (#92) Remove fixed tenors from part heads (e.g. `1342567890ET` is now be just `1342`).


### PR DESCRIPTION
`{bob,single}s_only` is much faster than `{single,bob}_weight` because it simply won't spend effort expanding a node that will always be removed by the next queue truncation.  However, sometimes singles are required (e.g. to get a 1250 of nearly all Treble Dodging Major methods) so it isn't correct for Monument to enable `{bob,single}s_only` automatically.