### PR TITLE
Rename `Regex` to `Pattern`, and enforce extra invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@
     ```
 
 ### BellFrame
-- (#97) Rename `music::Regex` to `music::Pattern` (it wasn't anywhere near as powerful as true
+- (#97) Enforce extra invariants for `music::Pattern` (making it much more robust, at the cost of
+    needing to handle some errors that should have been handled anyway).
+- (#97) Rename `music::Regex` to `music::Pattern` (it isn't anywhere near as powerful as true
     regexes).
 - (#96) Add `Stage::extent`, which returns a `SameStageVec` containing every possible `Row` of that
     `Stage` _in an arbitrary order_.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
     ```
 
 ### BellFrame
+- (#97) Rename `music::Regex` to `music::Pattern` (it wasn't anywhere near as powerful as true
+    regexes).
 - (#96) Add `Stage::extent`, which returns a `SameStageVec` containing every possible `Row` of that
     `Stage` _in an arbitrary order_.
 - (#96) Allow addition/subtraction between `Stage`s and `u8`s with `+`/`-`, panicking on overflow or

--- a/bellframe/README.md
+++ b/bellframe/README.md
@@ -41,5 +41,5 @@ operation is a bottleneck - it's just so much easier to know that simple code is
 #### Other Useful Types:
   - `Mask`: Like a `RowBuf`, except that bells can be missing (denoted by `x`).  For example,
     `1xxx5678` is a `Mask`, where 2,3,4 can go in any order.
-  - `Regex`: Default way of representing music patterns - like a `Mask`, except that `*` matches any
-    number of bells.  For example, `*x7x8x*` is a `Regex`.
+  - `Pattern`: Default way of representing music patterns - like a `Mask`, except that `*` matches any
+    number of bells.  For example, `*x7x8x*` is a `Pattern`.

--- a/bellframe/src/music.rs
+++ b/bellframe/src/music.rs
@@ -6,59 +6,61 @@ use std::{
 use factorial::Factorial;
 use itertools::Itertools;
 
-use crate::{utils, Bell, Row, RowBuf, Stage};
+use crate::{utils, Bell, IncompatibleStages, InvalidRowError, Row, RowBuf, Stage};
 
-/// A `Pattern` over sequences of [`Bell`]s (usually over [`Row`]s).
+/// A regex-like `Pattern` over [`Row`]s.
 ///
 /// A `Pattern` is a sequence of [`Elem`]ents, which can be one of three types:
-/// - An [`Elem::Bell`], written as the corresponding [`Bell`] name (e.g. `'1'`)
-/// - An [`Elem::X`] which matches exactly one of any [`Bell`], written as `'x'`
-/// - An [`Elem::Star`] which matches any number (including zero) of any [`Bell`], written as `'*'`
+/// - An [`Elem::Bell`], written as the corresponding [`Bell`] name (e.g. `1`)
+/// - An [`Elem::X`] which matches exactly one of any [`Bell`], written as `x`
+/// - An [`Elem::Star`] which matches any number (including zero) of any [`Bell`], written as `*`
 ///
 /// For example, `"*x5678x*"` matches at least one of any [`Bell`] (`"*x"`), followed by `"5678"`,
 /// followed by at least one of any [`Bell`] (`"x*"`).  In other words, `"*x5678x*` matches
 /// _internal 5678s_.
 ///
-/// `x`s and `*`s are known as 'wildcards', since they aren't bound to a specific [`Bell`].
+/// `x`s and `*`s are known as _'wildcards'_, since they aren't bound to a specific [`Bell`].
 ///
-/// Wildcards in `Pattern`s are normalised according to two rules:
-/// 1. If there is a sequence of consecutive `x`s and `*`s (e.g. `*x*x***`) then the `x`s
-///    will always come first, followed by the `*`s (this example would get reordered to
-///    `xx*****`).
-/// 2. Consecutive `*`s are reduced to a single `*` (this example would get fully normalised from
-///    `*x*x***` to `xx*****` then to `xx*`).
+/// # Normalisation and Invariants
+///
+/// Sequences of wildcards are always normalised into a sequence of `x`s, followed by at most one
+/// `*`.  For example, `x*xx***x` would be normalised to `xxxx*`.
+///
+/// Finally, all `Pattern`s must match at least one [`Row`] of its given [`Stage`].  This adds a
+/// few extra invariants (the latter two are shared with [`Row`] and [`Mask`](crate::Mask)):
+/// - The length of the `Pattern` is compatible with the [`Stage`] (e.g. `1234xxx` is too long for
+///   Minor, and `123` is too short for Minimus)
+/// - All [`Bell`]s must be within the [`Stage`] (e.g. `7*` is invalid for Minor)
+/// - All [`Bell`]s must be unique (e.g. `1x1*` is invalid for any [`Stage`]).
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct Pattern {
-    /// The pattern which represents this `Pattern`.  This is normalised with the following
-    /// invariants:
-    /// - There are never more than two stars in a row (because `**` is equivalent to `*`)
-    /// - If there is a sequence of consecutive 'any's and stars (e.g. `*x*`) then the 'any's
-    ///   will always come first, followed by the stars.
+    /// The sequence of [`Elem`]ents representing this `Pattern`.
     ///
-    /// These two rules feed into each other, so `*x*x` would be normalised to `xx**` (second rule:
-    /// reorder 'any's and stars) and then to `xx*` (first rule: compress consecutive stars).
-    ///
-    /// Therefore, after a star we can only have either a bell or the end of the pattern.
+    /// See [`Self::from_vec_unchecked`] for the invariants that `elems` must uphold.
     elems: Vec<Elem>,
+    /// The [`Stage`] of the [`Row`]s matched by this `Pattern`.  All `Pattern`s always have a
+    /// specific [`Stage`] as a safety check, even if, in theory, they would be able to match
+    /// [`Row`]s of many [`Stage`]s.
     stage: Stage,
 }
 
 /// A single `Elem`ent of a music [`Pattern`].
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Elem {
-    /// Matches one specific [`Bell`].  Written as that [`Bell`]'s name (e.g. `'5'`)
+    /// Matches one specific [`Bell`].  Written as that [`Bell`]'s name (e.g. `5`)
     Bell(Bell),
-    /// Matches one of any [`Bell`].  Written as `x` or `X`.
+    /// Matches one of any [`Bell`].  Written as `x` or `X` (`X` is not a valid [`Bell`] name for
+    /// this reason).
     X,
     /// Matches any number (including zero) of any [`Bell`]s.  Written as `*`.
     Star,
 }
 
 impl Pattern {
-    /// Parses a `Pattern` from a string.  A [`Bell`] name matches only that [`Bell`], `'x'` matches
-    /// precisely one of any [`Bell`] whereas `'*'` matches zero or more of any [`Bell`].  For
-    /// example, `"xxxx5678" and `"*5678"` both correspond to 56s on 8 bells.
-    pub fn parse(s: &str, stage: Stage) -> Self {
+    /// Parses a `Pattern` from a string.  A [`Bell`] name matches only that [`Bell`], `'x'` or
+    /// `'X'` matches precisely one of any [`Bell`] whereas `'*'` matches zero or more of any
+    /// [`Bell`].  For example, `"xxxx5678" and `"*5678"` both correspond to 56s on 8 bells.
+    pub fn parse(s: &str, stage: Stage) -> Result<Self, PatternError> {
         Self::from_elems(
             s.chars().filter_map(|c| match c {
                 'x' | 'X' => Some(Elem::X),
@@ -75,77 +77,95 @@ impl Pattern {
     }
 
     /// Creates a normalised `Pattern` from an [`Iterator`] of [`Elem`]s
-    pub fn from_elems(iter: impl IntoIterator<Item = Elem>, stage: Stage) -> Self {
+    pub fn from_elems(
+        iter: impl IntoIterator<Item = Elem>,
+        stage: Stage,
+    ) -> Result<Self, PatternError> {
         Self::from_vec(iter.into_iter().collect_vec(), stage)
+    }
+
+    /// Creates a `Pattern` from a [`Vec`] of [`Elem`]s, checking the invariants and normalising
+    /// the result.  This uses the allocation of the given [`Vec`].
+    pub fn from_vec(mut elems: Vec<Elem>, stage: Stage) -> Result<Self, PatternError> {
+        // Invariant 1: Normalise all `*x`s to `x*`s.  This is equivalent to taking every sequence
+        // of wildcards and rewriting it to have all the `x`s first.  (the `*`s will be compressed
+        // later).
+        //
+        // As a running example, this step would normalise `x*xx***5x6x7x8*x*`
+        //                                              to `xxx****5x6x7x8x**`
+        for wildcard_region in elems.split_mut(|e| e.is_bell()) {
+            let num_xs = wildcard_region.iter().filter(|e| e.is_x()).count();
+            let (region_of_xs, region_of_stars) = wildcard_region.split_at_mut(num_xs);
+            for e in region_of_xs {
+                *e = Elem::X;
+            }
+            for e in region_of_stars {
+                *e = Elem::Star;
+            }
+        }
+        // Invariant 2: Normalise any `**`s into `*`s.  We do this by removing any `*`s which
+        // precede a `*` (using `Vec::retain`).
+        //
+        // In the example,    `xxx****5x6x7x8x**`
+        // would normalise to `xxx*   5x6x7x8x* `
+        let mut is_last_elem_a_star = false;
+        elems.retain(|e| {
+            let should_remove = e.is_star() && is_last_elem_a_star;
+            is_last_elem_a_star = e.is_star();
+            !should_remove // `retain` keeps any elems which return `true`
+        });
+        // Invariants 3 & 4: `Bell`s are all unique and contained in the `Stage`
+        match crate::utils::check_duplicate_or_out_of_stage(
+            elems.iter().filter_map(|e| e.bell()),
+            stage,
+        ) {
+            Ok(()) => {} // Row is OK
+            Err(InvalidRowError::DuplicateBell(b)) => return Err(PatternError::DuplicateBell(b)),
+            Err(InvalidRowError::BellOutOfStage(b, s)) => {
+                return Err(PatternError::BellOutOfStage(b, s))
+            }
+            Err(InvalidRowError::NoBells | InvalidRowError::MissingBell(_)) => {
+                unreachable!("Zero-sized `Stage`s aren't possible")
+            }
+        }
+        // Invariant 5: length is compatible with the given `Stage`
+        let num_non_stars = elems.iter().filter(|e| **e != Elem::Star).count();
+        if num_non_stars > stage.num_bells() {
+            return Err(PatternError::TooLong(num_non_stars, stage)); // Too long
+        }
+        if !elems.contains(&Elem::Star) && num_non_stars < stage.num_bells() {
+            let string = elems.iter().map(Elem::to_string).join("");
+            return Err(PatternError::TooShort(num_non_stars, stage, string)); // Too short
+        }
+
+        // Unsafety is OK because `elems` has been normalised
+        Ok(unsafe { Self::from_vec_unchecked(elems, stage) })
     }
 
     /// Creates a `Pattern` from an [`Iterator`] of [`Elem`]s, without normalising.
     ///
     /// # Safety
     ///
-    /// This is safe if the incoming [`Iterator`] satisfies the wildcard normalisation rules.
+    /// See [`Pattern::from_vec_unchecked`] for safety requirements.
+    /// [`Pattern::from_vec_unchecked`] is called after collecting the [`Iterator`] into a [`Vec`].
     pub unsafe fn from_elems_unchecked(iter: impl IntoIterator<Item = Elem>, stage: Stage) -> Self {
         Self::from_vec_unchecked(iter.into_iter().collect_vec(), stage)
     }
 
-    /// Creates a normalised `Pattern` from a [`Vec`] of [`Elem`]s.
-    #[inline(always)]
-    pub fn from_vec(elems: Vec<Elem>, stage: Stage) -> Self {
-        // This unsafety is OK because the only operation we perform on the un-normalised Pattern is
-        // to normalise it (thus making it safe for other operations).
-        let mut r = unsafe { Self::from_vec_unchecked(elems, stage) };
-        r.normalise();
-        r
-    }
-
-    /// Creates a `Pattern` from a [`Vec`] of [`Elem`]s, without normalising.
+    /// Creates a `Pattern` from a [`Vec`] of [`Elem`]s, without normalising or checking invariants.
     ///
     /// # Safety
     ///
-    /// This is safe if the [`Vec`] satisfies the wildcard normalisation rules.
-    #[inline(always)]
+    /// This is only safe if `elems` satisfies the following invariants:
+    /// - `*x` doesn't appear anywhere; `*x` should be normalised to `x*`
+    /// - `**` doesn't appear anywhere; `**` should be normalised to `*`
+    /// - All [`Bell`]s are [`contained`](Stage::contains) within the given [`Stage`]
+    /// - All [`Bell`]s in `elems` are unique
+    /// - The resulting `Pattern` is able to match [`Row`]s of the given [`Stage`] (i.e. `elems` is
+    ///   neither too long nor too short).
+    #[inline]
     pub unsafe fn from_vec_unchecked(elems: Vec<Elem>, stage: Stage) -> Self {
         Self { elems, stage }
-    }
-
-    /// Normalises wildcards and stars in a `Pattern`.  This should only in combination with `unsafe`
-    /// - if only safe code is used, `self` will already be normalised.  This is the only operation
-    /// on `Pattern`s which doesn't rely on the input being normalised.
-    pub fn normalise(&mut self) {
-        // TODO: Perform stricter validity checks based on stage
-
-        let mut normalised_elems = Vec::<Elem>::with_capacity(self.elems.len());
-
-        // Insert a rogue bell to the end `self.elems` so that all runs of consecutive
-        // wildcards/stars end in a bell
-        self.elems.push(Elem::Bell(Bell::TREBLE));
-        // Split the elements into chunks of 0 or more wildcards/stars, each of which finishes with
-        // a bell.
-        for slice in self.elems.split_inclusive(|e| matches!(e, Elem::Bell(_))) {
-            // The slice should contain at least one element (the bell that matched the pattern)
-            assert!(!slice.is_empty());
-            let wildcards_pattern = &slice[..slice.len() - 1];
-            let bell_elem = slice[slice.len() - 1];
-            // Normalise the wildcard pattern, and push it.  To normalise it, we move all the 'x's
-            // to the start of the pattern and then add a single star (if the pattern contains any
-            // stars).
-            let num_wildcards = wildcards_pattern
-                .iter()
-                .filter(|e| matches!(e, Elem::X))
-                .count();
-            normalised_elems.extend(std::iter::repeat(Elem::X).take(num_wildcards));
-            if wildcards_pattern.contains(&Elem::Star) {
-                normalised_elems.push(Elem::Star);
-            }
-            // Push the bell that terminates this wildcard pattern
-            normalised_elems.push(bell_elem);
-        }
-
-        // Overwrite this pattern with the normalised element list
-        self.elems = normalised_elems;
-        // Pop the rogue bell off the end of the pattern (we added it before the loop to make the
-        // code cleaner).
-        assert_eq!(self.elems.pop(), Some(Elem::Bell(Bell::TREBLE)));
     }
 
     /// Creates a set of `Pattern`s which match runs of a given length off the **front** of a
@@ -224,7 +244,6 @@ impl Pattern {
         for i in 0..=num_bells - len {
             // An iterator that yields the bells forming this run in ascending order
             let run_iterator = (i..i + len).map(Bell::from_index).map(Elem::Bell);
-
             // This unsafety is OK because all of the input patterns must be normalised because
             // they contain only one wildcard
             let descending_pattern = unsafe {
@@ -238,7 +257,6 @@ impl Pattern {
                     stage,
                 )
             };
-
             runs.push(descending_pattern);
             runs.push(ascending_pattern);
         }
@@ -317,64 +335,64 @@ impl Pattern {
     pub fn num_matching_rows(&self) -> Option<usize> {
         // Each pattern has some (possibly empty) set of 'unfixed' bells: i.e. those which don't
         // appear in the pattern.  For example, the pattern `*1x*56*78` on Major has `{2,3,4}` as its
-        // unfixed bells.  These unfixed bells can either be placed in `x`s (i.e. exactly one bell
-        // per `x`) or into `*`s (i.e. any non-negative number of bells per `*`).  All bells must
+        // unfixed bells.  These unfixed bells can either be placed in 'x's (i.e. exactly one bell
+        // per 'x') or into '*'s (i.e. any non-negative number of bells per '*').  All bells must
         // appear exactly once in the resulting row, so we must _partition_ the 'unfixed' bells
-        // into the `x`s or the `*`s.
+        // into the 'x's or the '*'s.
         //
         // To derive the formula for this, suppose that we have `n` unfixed bells, which must be
-        // divided into `i` 'x's and `j` '*'s.  To enumerate every possibility, we must first
+        // divided into `x` 'x's and `s` '*'s.  To enumerate every possibility, we must first
         // assign a bell to each of the 'x's, then (for each of these assignments) partition the
         // remaining bells between the '*'s.
         //
-        // The number of assignments of `n` bells into `i` 'x's is simply `n choose i`.  Now we're
-        // left with the remaining `n - i` bells to distribute into `j` '*'s.  This step is not as
+        // The number of assignments of `n` bells into `x` 'x's is simply `n choose x`.  Now we're
+        // left with the remaining `n - x` bells to distribute into `s` '*'s.  This step is not as
         // simple, but nonetheless there is a nice way to re-frame the problem: instead of
-        // distributing the bells into `j` '*'s, we choose to split the bells up by inserting
-        // `j - 1` identical barriers.
+        // distributing the bells into `s` '*'s, we choose to split the bells up by inserting
+        // `s - 1` identical barriers.
         //
         // For example, if we have bells 1,2,3,4,5,6 to split into 3 '*'s, we instead insert two
         // barriers (denoted with `|`) into the sequence of bells being permuted.  So now, we are
         // looking for the number of arrangements of `123456||` (for example `62|35|41`, `|4|16532`
         // or `||654321`).  These correspond precisely to the arrangements into '*'s.
         //
-        // Now to find the formula: there are `(n - i + j - 1)!` arrangements of the bells and
+        // Now to find the formula: there are `(n - x + s - 1)!` arrangements of the bells and
         // barriers, but the barriers are all identical so these permutations are over-counted by
-        // `(j - 1)!` times (assuming that `(-1)! = 1`).  Putting this together, for each way of
-        // assigning bells to 'x's there are `(n - i + j - 1)! / (j - 1)!` ways to distribute the
+        // `(s - 1)!` times (assuming that `(-1)! = 1`).  Putting this together, for each way of
+        // assigning bells to 'x's there are `(n - x + s - 1)! / (s - 1)!` ways to distribute the
         // remaining bells into the '*'s.
         //
         // Multiplying both of these terms will give the total number of matching `Row`s
 
-        // Compute the values of `n` (num_unfixed), `i` (num_wildcards) and `j` (num_stars) by
+        // Compute the values of `n` (num_unfixed), `x` (num_xs) and `s` (num_stars) by
         // iterating over the pattern and counting.
         let mut num_unfixed = self.stage.num_bells(); // `n`, decremented for each fixed bell
-        let mut num_wildcards = 0usize; // `i`
-        let mut num_stars = 0usize; // `j`
+        let mut num_xs = 0usize; // `x`
+        let mut num_stars = 0usize; // `s`
         for e in &self.elems {
             match e {
                 Elem::Bell(_) => num_unfixed -= 1,
-                Elem::X => num_wildcards += 1,
+                Elem::X => num_xs += 1,
                 Elem::Star => num_stars += 1,
             }
         }
 
-        let ways_to_fill_wildcards = utils::choice(num_unfixed, num_wildcards)?;
+        let ways_to_fill_xs = utils::choice(num_unfixed, num_xs)?;
 
         // TODO: Compute the fraction directly to limit potential for overflow
-        let num_bells_in_stars = num_unfixed - num_wildcards;
+        let num_bells_in_stars = num_unfixed - num_xs;
         let ways_to_fill_stars_numerator =
-            (num_bells_in_stars + num_wildcards.saturating_sub(1)).checked_factorial()?;
+            (num_bells_in_stars + num_xs.saturating_sub(1)).checked_factorial()?;
         let ways_to_fill_stars_denominator = num_stars.saturating_sub(1).checked_factorial()?;
         let ways_to_fill_stars = ways_to_fill_stars_numerator / ways_to_fill_stars_denominator;
 
-        Some(ways_to_fill_wildcards * ways_to_fill_stars)
+        Some(ways_to_fill_xs * ways_to_fill_stars)
     }
 
     /// Returns `true` if a given [`Row`] satisfies this `Pattern`, and `false` otherwise.  If the
     /// normalised `Pattern` contains `n` elements and the [`Row`] contains `m` [`Bell`]s, the
     /// runtime is `O(n + m)`.
-    pub fn matches(&self, r: &Row) -> bool {
+    pub fn matches(&self, r: &Row) -> Result<bool, IncompatibleStages> {
         // Run a match, ignoring the indices which are a match
         self.run_match(r, |_i| ())
     }
@@ -382,18 +400,16 @@ impl Pattern {
     /// Returns the **0-indexed** places of the [`Bell`]s which match this `Pattern` (or `None` if
     /// the [`Row`] doesn't match).  The places will always be sorted in ascending order.  If the
     /// [`Row`] isn't matched, `None` is returned.
-    pub fn match_pattern(&self, r: &Row) -> Option<Vec<usize>> {
+    pub fn match_pattern(&self, r: &Row) -> Result<Option<Vec<usize>>, IncompatibleStages> {
         // Run the matching algorithm, storing where the bells match
         let mut matches = Vec::<usize>::new();
-        let is_match = self.run_match(r, |i| matches.push(i));
+        let is_match = self.run_match(r, |i| matches.push(i))?;
 
-        if is_match {
-            // If the row did match, then return the places
-            Some(matches)
+        Ok(if is_match {
+            Some(matches) // If the row did match, then return the places
         } else {
-            // If the row turns out not to match the row, return an empty match
-            None
-        }
+            None // If the row turns out not to match the row, return an empty match
+        })
     }
 
     /// Helper function to test a match between a [`Row`] and this `Pattern`, calling some function
@@ -401,8 +417,13 @@ impl Pattern {
     ///
     /// If the normalised `Pattern` contains `n` elements and the [`Row`] contains `m` [`Bell`]s, the
     /// runtime is `O(n + m)`.
-    #[inline(always)]
-    fn run_match(&self, r: &Row, mut match_fn: impl FnMut(usize)) -> bool {
+    fn run_match(
+        &self,
+        r: &Row,
+        mut match_fn: impl FnMut(usize),
+    ) -> Result<bool, IncompatibleStages> {
+        IncompatibleStages::test_err(self.stage(), r.stage())?;
+
         /* Note: This algorithm relies on the uniqueness of bells within rows, so cannot be used
          * on arbitrary iterators of bells */
 
@@ -413,7 +434,7 @@ impl Pattern {
         loop {
             // If we haven't run out of pattern elements, then test the patterns
             match pattern_elems.next() {
-                // If the next element is a specific bell, then the next bell must be the same
+                // If the next element is a specific bell, then the next bell must be matched
                 Some(Elem::Bell(exp_bell)) => {
                     match bells.next() {
                         Some((i, b)) => {
@@ -424,18 +445,18 @@ impl Pattern {
                             } else {
                                 // If the bell didn't match what we expected, the entire row
                                 // doesn't match
-                                return false;
+                                return Ok(false);
                             }
                         }
                         // If the pattern expected a bell but the row finished, then the row doesn't
                         // match
-                        None => return false,
+                        None => return Ok(false),
                     }
                 }
                 // If the pattern is 'Any', then the row matches if it has more bells left
                 Some(Elem::X) => {
                     if bells.next().is_none() {
-                        return false;
+                        return Ok(false);
                     }
                 }
                 // If the next element is a star, then we need to look ahead at the next expected
@@ -458,12 +479,12 @@ impl Pattern {
                                 }
                                 // If we consume the entire row without finding the wanted bell,
                                 // the pattern doesn't match
-                                None => return false,
+                                None => return Ok(false),
                             }
                         }
                     }
                     // If the pattern ends with a star, then any extension of the row matches
-                    None => return true,
+                    None => return Ok(true),
                     // Because of normalisation, a star cannot be followed by anything other than a
                     // bell (or the end of the pattern).  This branch should only be reachable with
                     // `unsafe`
@@ -471,7 +492,7 @@ impl Pattern {
                 },
                 // If we've run out of pattern elements, then the row matches iff we also run out of
                 // bells at the same time
-                None => return bells.next().is_none(),
+                None => return Ok(bells.next().is_none()),
             }
         }
     }
@@ -552,26 +573,119 @@ impl From<RowBuf> for Pattern {
     }
 }
 
+////////////
+// ERRORS //
+////////////
+
+/// Possible errors created when constructing a [`Pattern`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PatternError {
+    DuplicateBell(Bell),
+    BellOutOfStage(Bell, Stage),
+    TooShort(usize, Stage, String),
+    TooLong(usize, Stage),
+}
+
+impl PatternError {
+    pub(crate) fn write_message(
+        &self,
+        f: &mut impl std::fmt::Write,
+        whats_being_parsed: &str,
+    ) -> std::fmt::Result {
+        match self {
+            PatternError::BellOutOfStage(bell, stage) => {
+                write!(f, "bell {} is out of stage {}", bell, stage)
+            }
+            PatternError::DuplicateBell(bell) => write!(f, "bell {} appears twice", bell),
+            PatternError::TooShort(len, stage, string) => {
+                let extended_tenors = stage
+                    .bells()
+                    .skip(*len)
+                    .map(|b| b.to_char().unwrap())
+                    .collect::<String>();
+                write!(
+                    f,
+                    "{} is too short; did you mean `{}*` or `{}{}`?",
+                    whats_being_parsed, string, string, extended_tenors
+                )
+            }
+            PatternError::TooLong(len, stage) => write!(
+                f,
+                "{} is too long, needing at least {} bells (too many for {})",
+                whats_being_parsed, len, stage
+            ),
+        }
+    }
+}
+
+impl Display for PatternError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.write_message(f, "pattern")
+    }
+}
+
+impl std::error::Error for PatternError {}
+
 #[cfg(test)]
 mod tests {
-    use crate::{RowBuf, Stage};
+    use crate::{Bell, RowBuf, Stage};
 
-    use super::Pattern;
+    use super::{Pattern, PatternError};
+
+    #[test]
+    fn pattern_parse_err() {
+        #[track_caller]
+        fn check_exceeds_stage(pattern: &str, num_bells: u8, bell: char) {
+            let stage = Stage::new(num_bells);
+            let bell = Bell::from_name(bell).unwrap();
+            assert_eq!(
+                Pattern::parse(pattern, stage),
+                Err(PatternError::BellOutOfStage(bell, stage))
+            );
+        }
+        #[track_caller]
+        fn check_too_short(pattern: &str, num_bells: u8, length: usize) {
+            let stage = Stage::new(num_bells);
+            assert!(length < stage.num_bells());
+            assert_eq!(
+                Pattern::parse(pattern, stage),
+                Err(PatternError::TooShort(length, stage, pattern.to_owned()))
+            );
+        }
+        #[track_caller]
+        fn check_too_long(pattern: &str, num_bells: u8, length: usize) {
+            let stage = Stage::new(num_bells);
+            assert!(length > stage.num_bells());
+            assert_eq!(
+                Pattern::parse(pattern, stage),
+                Err(PatternError::TooLong(length, stage))
+            );
+        }
+
+        check_exceeds_stage("xxx5", 4, '5');
+        check_exceeds_stage("*5", 4, '5');
+        check_exceeds_stage("5*", 4, '5');
+        check_too_short("xx3", 4, 3);
+        check_too_short("3421", 8, 4);
+        check_too_long("xxxx3x", 4, 6);
+        check_too_long("xxxx3*", 4, 5);
+    }
 
     #[test]
     fn pattern_normalise() {
         #[track_caller]
         fn check(inp_str: &str, exp_str: &str) {
-            println!("Testing {:?}", inp_str);
-            assert_eq!(Pattern::parse(inp_str, Stage::MAJOR).to_string(), exp_str);
+            assert_eq!(
+                Pattern::parse(inp_str, Stage::MAJOR).unwrap().to_string(),
+                exp_str
+            );
         }
 
-        check("", "");
         check("*", "*");
         check("**", "*");
         check("***", "*");
         check("****", "*");
-        check("x", "x");
+        check("1x2*x**", "1x2x*");
         check("**5678", "*5678");
         check("*1**", "*1*");
         check("*1", "*1");
@@ -583,14 +697,12 @@ mod tests {
     }
 
     #[test]
-    fn pattern_is_match() {
+    fn is_match() {
         #[track_caller]
         fn check(pattern_str: &str, row_str: &str, expected_match: bool) {
-            println!("Testing row {} against pattern {}", row_str, pattern_str);
-
             let row = &RowBuf::parse(row_str).unwrap();
-            let pattern = Pattern::parse(pattern_str, row.stage());
-            let is_match = pattern.matches(&row);
+            let pattern = Pattern::parse(pattern_str, row.stage()).unwrap();
+            let is_match = pattern.matches(&row).unwrap();
 
             match (expected_match, is_match) {
                 (true, false) => {
@@ -606,17 +718,16 @@ mod tests {
 
         // Pattern with only 'x's
         check("xxxx", "3412", true);
-        check("xxxx", "4321", true);
-        check("xxxx", "54321", false);
+        check("xxXx", "4321", true);
+        check("xxxxX", "54321", true);
         // Pattern with only 'x's and numbers
         check("x1xx", "2134", true);
         check("x1xx", "2134", true);
         check("x1xx", "4321", false);
-        check("x1", "21345", false);
+        check("x1xxX", "21345", true);
         // Pattern with stars
         check("*1234", "1234", true);
         check("*1234", "51234", true);
-        check("*1234", "123", false);
         check("*6578", "12346578", true);
         check("*65*78", "12346578", true);
         check("*65*78", "12653478", true);
@@ -625,34 +736,30 @@ mod tests {
         check("x*12*34", "61257834", true);
         check("x*12*34", "12657834", false);
         check("x*12*34", "51234", true);
-        check("x*12*34", "1234", false);
         check("x*12*34", "12534", false);
     }
 
     #[test]
-    fn pattern_match_pattern() {
+    fn match_pattern() {
         #[track_caller]
         fn check(pattern_str: &str, row_str: &str, expected_pattern: Option<Vec<usize>>) {
-            println!("Testing row {} against pattern {}", row_str, pattern_str);
-
             let row = &RowBuf::parse(row_str).unwrap();
-            let pattern = Pattern::parse(pattern_str, row.stage());
-            assert_eq!(pattern.match_pattern(&row), expected_pattern);
+            let pattern = Pattern::parse(pattern_str, row.stage()).unwrap();
+            assert_eq!(pattern.match_pattern(&row).unwrap(), expected_pattern);
         }
 
         // Patterns with only 'x's
         check("xxxx", "3412", Some(vec![]));
         check("xxXx", "4321", Some(vec![]));
-        check("XXXX", "54321", None);
+        check("XXXXx", "54321", Some(vec![]));
         // Patterns with only 'x's and numbers
         check("x1xx", "2134", Some(vec![1]));
         check("x1xx", "2134", Some(vec![1]));
         check("x1xx", "4321", None);
-        check("x1", "21345", None);
+        check("x1xxx", "21345", Some(vec![1]));
         // Patterns with stars
         check("*1234", "1234", Some(vec![0, 1, 2, 3]));
         check("*1234", "51234", Some(vec![1, 2, 3, 4]));
-        check("*1234", "123", None);
         check("*6578", "12346578", Some(vec![4, 5, 6, 7]));
         check("*65*78", "12346578", Some(vec![4, 5, 6, 7]));
         check("*65*78", "12653478", Some(vec![2, 3, 6, 7]));
@@ -661,7 +768,6 @@ mod tests {
         check("x*12*34", "61257834", Some(vec![1, 2, 6, 7]));
         check("x*12*34", "12657834", None);
         check("x*12*34", "51234", Some(vec![1, 2, 3, 4]));
-        check("x*12*34", "1234", None);
         check("x*12*34", "12534", None);
         check("*1x2x3x4*", "18273645", Some(vec![0, 2, 4, 6]));
         check("*1x2x3x4*", "091E273645T8", Some(vec![2, 4, 6, 8]));

--- a/bellframe/src/utils.rs
+++ b/bellframe/src/utils.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Bound, Range, RangeBounds},
 };
 
-use crate::Bell;
+use crate::{Bell, InvalidRowError, Stage};
 use itertools::Itertools;
 
 /// Helper function to calculate the length of the longest run off the start of a given
@@ -16,6 +16,35 @@ pub fn run_len(iter: impl IntoIterator<Item = Bell>) -> usize {
         .take_while(|&(i1, i2)| (i1 as i8 - i2 as i8).abs() == 1)
         .count()
         + 1
+}
+
+/// Given some [`Bell`]s and a [`Stage`], simultaneously check for duplicate [`Bell`]s and any
+/// [`Bell`]s which are too big for the given [`Stage`].
+pub(crate) fn check_duplicate_or_out_of_stage(
+    bells: impl IntoIterator<Item = Bell>,
+    stage: Stage,
+) -> Result<(), InvalidRowError> {
+    // We check validity by keeping a checklist of which `Bell`s we've seen, and checking off
+    // each bell as we go.  PERF: use a bitmap here
+    let mut checklist = vec![false; stage.num_bells()];
+    // Loop over all the bells to check them off in the checklist.  We do not need to check for
+    // empty spaces in the checklist once we've done because (by the Pigeon Hole Principle),
+    // fitting `n` bells into `n` slots with some gaps will always require that a bell is
+    // either out of range or two bells share a slot.
+    for b in bells {
+        match checklist.get_mut(b.index()) {
+            // If the `Bell` is out of range of the checklist, it can't belong within the
+            // `Stage` of this `Row`
+            None => return Err(InvalidRowError::BellOutOfStage(b, stage)),
+            // If the `Bell` has already been seen before, then it must be a duplicate
+            Some(&mut true) => return Err(InvalidRowError::DuplicateBell(b)),
+            // If the `Bell` has not been seen before, check off the checklist entry and
+            // continue
+            Some(x) => *x = true,
+        }
+    }
+    // If none of the `Bell`s caused errors, the row must be valid
+    Ok(())
 }
 
 /// Converts any [`RangeBounds`] (i.e. `x..=y`, `..y`, `..`, etc.) into a concrete [`Range`], where

--- a/monument/cli/src/default-music-triples.toml
+++ b/monument/cli/src/default-music-triples.toml
@@ -12,7 +12,7 @@ show = false
 
 # Queens and Kings
 [[music]]
-patterns = ["13572468", "75312468"]
+patterns = ["1357246", "7531246"]
 weight = 3
 show = false
 

--- a/monument/cli/src/music.rs
+++ b/monument/cli/src/music.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, fmt::Write};
 
 use bellframe::{
-    music::{Regex, RegexElem},
+    music::{Elem, Pattern},
     Bell, RowBuf, Stage,
 };
 use itertools::Itertools;
@@ -276,28 +276,28 @@ fn music_type_runs(
     if common.show && common.name.is_none() {
         for &len in lengths {
             let pattern_name = format!("{}-bell run", len);
-            let mut all_regexes = Vec::new(); // Used to create the `MusicType` for the total
+            let mut all_patterns = Vec::new(); // Used to create the `MusicType` for the total
 
             // Closure to add a `MusicType` for runs in some position
             let mut push_runs = |position: PatternPosition| {
-                let regexes = match position {
-                    PatternPosition::Front => Regex::runs_front(stage, len),
-                    PatternPosition::Internal => Regex::runs_internal(stage, len),
-                    PatternPosition::Back => Regex::runs_back(stage, len),
+                let patterns = match position {
+                    PatternPosition::Front => Pattern::runs_front(stage, len),
+                    PatternPosition::Internal => Pattern::runs_internal(stage, len),
+                    PatternPosition::Back => Pattern::runs_back(stage, len),
                     PatternPosition::Total => unreachable!(),
                 };
                 // Add `MusicType` for the front/back/internal count
                 music_types.push((
-                    MusicType::new(regexes.clone(), common.strokes, 0.0, OptRange::default()),
+                    MusicType::new(patterns.clone(), common.strokes, 0.0, OptRange::default()),
                     Some(MusicTypeDisplay {
                         full_name: String::new(),
                         pattern: Some((pattern_name.clone(), position)),
                     }),
                 ));
-                // Make sure that the regexes get included in the total
-                all_regexes.extend(regexes);
+                // Make sure that the patterns get included in the total
+                all_patterns.extend(patterns);
             };
-            // Add front/internal/back regexes
+            // Add front/internal/back patterns
             push_runs(PatternPosition::Front);
             if internal {
                 push_runs(PatternPosition::Internal);
@@ -307,7 +307,7 @@ fn music_type_runs(
             // the scoring weight
             music_types.push((
                 MusicType::new(
-                    all_regexes,
+                    all_patterns,
                     common.strokes,
                     common.weight,
                     OptRange::default(),
@@ -324,9 +324,9 @@ fn music_type_runs(
     let count_range = OptRange::from(common.count_range);
     let need_to_add_weight = music_types.is_empty();
     if count_range.is_set() || need_to_add_weight {
-        let regexes = lengths
+        let patterns = lengths
             .iter()
-            .flat_map(|length| Regex::runs(stage, *length, internal))
+            .flat_map(|length| Pattern::runs(stage, *length, internal))
             .collect_vec();
         let weight = if need_to_add_weight {
             common.weight
@@ -336,7 +336,7 @@ fn music_type_runs(
         // Runs can't take the `count_each` parameter, so can all be grouped into one
         // `MusicType`
         music_types.push((
-            MusicType::new(regexes, common.strokes, weight, count_range),
+            MusicType::new(patterns, common.strokes, weight, count_range),
             None,
         ));
     }
@@ -350,7 +350,7 @@ fn music_type_patterns(
     common: &MusicCommon,
     stage: Stage,
 ) -> Vec<(MusicType, Option<MusicTypeDisplay>)> {
-    let regexes = patterns.iter().map(|s| Regex::parse(s, stage));
+    let patterns = patterns.iter().map(|s| Pattern::parse(s, stage));
     let individual_count = OptRange::from(count_each);
     let combined_count = OptRange::from(common.count_range);
 
@@ -358,16 +358,21 @@ fn music_type_patterns(
 
     // Create music types for the individual groups
     if individual_count.is_set() || (common.show && common.name.is_none()) {
-        types.extend(regexes.clone().map(|regex| {
+        types.extend(patterns.clone().map(|pattern| {
             let name = match (common.show, &common.name) {
-                (true, None) => Some(MusicTypeDisplay::from_regex(&regex)),
+                (true, None) => Some(MusicTypeDisplay::from_pattern(&pattern)),
                 // If `show = true` and `name` is set, then this group *as a whole* will be named
                 (true, Some(_)) => None,
                 (false, _) => None, // If `show = false`, then no names are generated
             };
 
             (
-                MusicType::new(vec![regex], common.strokes, common.weight, individual_count),
+                MusicType::new(
+                    vec![pattern],
+                    common.strokes,
+                    common.weight,
+                    individual_count,
+                ),
                 name,
             )
         }));
@@ -376,14 +381,14 @@ fn music_type_patterns(
     if types.is_empty() || combined_count.is_set() || (common.show && common.name.is_some()) {
         let name = match (common.show, &common.name) {
             (true, Some(name)) => Some(MusicTypeDisplay::with_custom_name(name)),
-            // If `common.show = true` but `common.name` is not set, then the regexes will be named
+            // If `common.show = true` but `common.name` is not set, then the patterns will be named
             // individually
             (true, None) => None,
             (false, _) => None, // If `common.show = false`, then no name is given
         };
         types.push((
             MusicType::new(
-                regexes.collect_vec(),
+                patterns.collect_vec(),
                 common.strokes,
                 // If individual `MusicType`s have already been created, then give the combined
                 // `MusicType` a weight of 0 so everything isn't counted twice
@@ -402,7 +407,7 @@ fn music_type_preset(
     common: &MusicCommon,
     stage: Stage,
 ) -> anyhow::Result<Vec<(MusicType, Option<MusicTypeDisplay>)>> {
-    // Determine the regex types
+    // Determine the pattern types
     let (combined_patterns, front_back_patterns, default_name) = match preset {
         MusicPreset::Combinations5678s => match stage {
             // For Triples, `8` is always at the back, so `5678` combinations are any point where
@@ -410,10 +415,10 @@ fn music_type_preset(
             Stage::TRIPLES => {
                 let mut patterns = Vec::new();
                 for singles_row in &Stage::SINGLES.extent() {
-                    let mut pattern = vec![RegexElem::Glob];
+                    let mut pattern = vec![Elem::Star];
                     // Map `123` into `567` by adding 4 to each `Bell`
-                    pattern.extend(singles_row.bell_iter().map(|b| b + 4).map(RegexElem::Bell));
-                    patterns.push(Regex::from_vec(pattern, stage));
+                    pattern.extend(singles_row.bell_iter().map(|b| b + 4).map(Elem::Bell));
+                    patterns.push(Pattern::from_vec(pattern, stage));
                 }
                 (patterns, None, "5678 comb")
             }
@@ -423,16 +428,16 @@ fn music_type_preset(
                 let mut patterns_back = Vec::new();
                 for minimus_row in &Stage::MINIMUS.extent() {
                     // Map `1234` to `5678` by adding 4 to each `Bell`
-                    let bells_5678 = minimus_row.bell_iter().map(|b| b + 4).map(RegexElem::Bell);
+                    let bells_5678 = minimus_row.bell_iter().map(|b| b + 4).map(Elem::Bell);
                     patterns_front.push({
                         let mut pat = bells_5678.clone().collect_vec();
-                        pat.push(RegexElem::Glob);
-                        Regex::from_vec(pat, stage)
+                        pat.push(Elem::Star);
+                        Pattern::from_vec(pat, stage)
                     });
                     patterns_back.push({
-                        let mut pat = vec![RegexElem::Glob];
+                        let mut pat = vec![Elem::Star];
                         pat.extend(bells_5678.clone());
-                        Regex::from_vec(pat, stage)
+                        Pattern::from_vec(pat, stage)
                     });
                 }
                 // Combine front/back to create `patterns_both`
@@ -456,7 +461,7 @@ fn music_type_preset(
                 .map(|swap_idx| {
                     let mut pattern_row = RowBuf::rounds(stage);
                     pattern_row.swap(swap_idx, swap_idx + 1);
-                    Regex::from(pattern_row)
+                    Pattern::from(pattern_row)
                 })
                 .collect_vec();
             (patterns, None, "NM")
@@ -472,13 +477,13 @@ fn music_type_preset(
                 .map(|(b1, b2)| {
                     // "*{b1}{b2}"
                     let mut cru = vec![
-                        RegexElem::Glob,
-                        RegexElem::Bell(Bell::from_number(b1).unwrap()),
-                        RegexElem::Bell(Bell::from_number(b2).unwrap()),
+                        Elem::Star,
+                        Elem::Bell(Bell::from_number(b1).unwrap()),
+                        Elem::Bell(Bell::from_number(b2).unwrap()),
                     ];
                     // "7890..."
-                    cru.extend(stage.bells().skip(6).map(RegexElem::Bell));
-                    Regex::from_vec(cru, stage)
+                    cru.extend(stage.bells().skip(6).map(Elem::Bell));
+                    Pattern::from_vec(cru, stage)
                 })
                 .collect_vec();
             (patterns, None, "CRU")
@@ -538,7 +543,7 @@ fn music_type_preset(
 #[derive(Debug, Clone)]
 struct MusicTypeDisplay {
     /// A specific full name given to this [`MusicType`], used when this row isn't part of a
-    /// combined pattern.  Usually this is the compressed regex (e.g. `*5678`) or a specific name,
+    /// combined pattern.  Usually this is the compressed pattern (e.g. `*5678`) or a specific name,
     /// like `"87s at back"` or `"Queens"`.
     full_name: String,
     /// The [`MusicType`] is a pattern applied to one end of the [`Row`].  For example:
@@ -565,53 +570,53 @@ impl MusicTypeDisplay {
         }
     }
 
-    fn from_regex(regex: &Regex) -> Self {
+    fn from_pattern(pattern: &Pattern) -> Self {
         Self {
-            full_name: regex.to_string(),
-            pattern: Self::pattern(regex),
+            full_name: pattern.to_string(),
+            pattern: Self::pattern(pattern),
         }
     }
 
-    /// Given a [`Regex`], try to determine the underlying pattern, as well as its
+    /// Given a [`Pattern`], try to determine the underlying pattern, as well as its
     /// [`PatternPosition`] within a [`Row`].
-    fn pattern(regex: &Regex) -> Option<(String, PatternPosition)> {
+    fn pattern(pattern: &Pattern) -> Option<(String, PatternPosition)> {
         // If a row is all wildcards, then no pattern is possible
-        if regex.elems().iter().all(|elem| elem.is_wildcard()) {
+        if pattern.elems().iter().all(|elem| elem.is_wildcard()) {
             return None;
         }
 
-        // Split the `Regex` into 3 sections:
+        // Split the `Pattern` into 3 sections:
         // 1. A prefix of wildcards
         // 2. A centre chunk, starting and ending with a specific bell, which is used to name the
         //    pattern
         // 3. A suffix of wildcards
-        let wildcard_prefix_len = regex
+        let wildcard_prefix_len = pattern
             .elems()
             .iter()
             .find_position(|elem| elem.is_bell())
-            .unwrap() // This will only panic if the regex contains no bells (which is checked)
+            .unwrap() // This will only panic if the pattern contains no bells (which is checked)
             .0; // `find_position(_).unwrap()` returns `(index, element)`, but we just want the index
-        let wildcard_suffix_len = regex
+        let wildcard_suffix_len = pattern
             .elems()
             .iter()
             .rev()
             .find_position(|elem| elem.is_bell())
-            .unwrap() // This will only panic if the regex contains no bells (which is checked)
+            .unwrap() // This will only panic if the pattern contains no bells (which is checked)
             .0; // `find_position(_).unwrap()` returns `(index, element)`, but we just want the index
-        let wildcard_suffix_start = regex.elems().len() - wildcard_suffix_len;
-        let (head, wildcard_suffix) = regex.elems().split_at(wildcard_suffix_start);
+        let wildcard_suffix_start = pattern.elems().len() - wildcard_suffix_len;
+        let (head, wildcard_suffix) = pattern.elems().split_at(wildcard_suffix_start);
         let (wildcard_prefix, pattern_elems) = head.split_at(wildcard_prefix_len);
 
-        // Check each section for `*`s.  Regex normalisation tells us that the prefix and suffix
-        // can contain at most one glob each
-        let star_in_prefix = wildcard_prefix.contains(&RegexElem::Glob);
-        let star_in_pattern = pattern_elems.contains(&RegexElem::Glob);
-        let star_in_suffix = wildcard_suffix.contains(&RegexElem::Glob);
+        // Check each section for `*`s.  Pattern normalisation tells us that the prefix and suffix
+        // can contain at most one star each
+        let star_in_prefix = wildcard_prefix.contains(&Elem::Star);
+        let star_in_pattern = pattern_elems.contains(&Elem::Star);
+        let star_in_suffix = wildcard_suffix.contains(&Elem::Star);
         // Count the number of `x`s in the suffix or prefix
         let xs_in_prefix = wildcard_prefix.iter().filter(|e| e.is_x()).count();
         let xs_in_suffix = wildcard_suffix.iter().filter(|e| e.is_x()).count();
 
-        // If the internal pattern contains a `*`, then the regex can't have a position
+        // If the internal pattern contains a `*`, then the pattern can't have a position
         if star_in_pattern {
             return None;
         }
@@ -633,9 +638,9 @@ impl MusicTypeDisplay {
                 (xs_in_prefix, xs_in_suffix, PatternPosition::Total)
             }
         } else {
-            // At this point, we know that `regex` contains at most one `*`, and that it is in one of
+            // At this point, we know that `pattern` contains at most one `*`, and that it is in one of
             // the suffix or prefix
-            let num_stars = regex.elems().iter().filter(|e| e.is_star()).count();
+            let num_stars = pattern.elems().iter().filter(|e| e.is_star()).count();
             assert!(num_stars <= 1);
             assert!(!star_in_pattern);
 
@@ -643,8 +648,8 @@ impl MusicTypeDisplay {
             // and use that to compute the exact lengths of the suffix and prefix.
             //
             // The length of the star is the number of bells missing once every other element in the
-            // regex is accounted for.
-            let star_len = regex.stage().num_bells() - (regex.elems().len() - num_stars);
+            // pattern is accounted for.
+            let star_len = pattern.stage().num_bells() - (pattern.elems().len() - num_stars);
             let prefix_len = xs_in_prefix + if star_in_prefix { star_len } else { 0 };
             let suffix_len = xs_in_suffix + if star_in_suffix { star_len } else { 0 };
 
@@ -780,21 +785,21 @@ fn compute_music_displays(
 
 #[cfg(test)]
 mod tests {
-    use bellframe::{music::Regex, Stage};
+    use bellframe::{music::Pattern, Stage};
 
     use super::{MusicTypeDisplay, PatternPosition};
 
     #[test]
-    fn extract_regex_pattern() {
+    fn extract_pattern_pattern() {
         #[track_caller]
         fn check(
-            regex_str: &str,
+            pattern_str: &str,
             stage: Stage,
             expected_pattern: &str,
             expected_position: PatternPosition,
         ) {
-            let regex = Regex::parse(regex_str, stage);
-            let (actual_pattern, actual_position) = MusicTypeDisplay::pattern(&regex).unwrap();
+            let pattern = Pattern::parse(pattern_str, stage);
+            let (actual_pattern, actual_position) = MusicTypeDisplay::pattern(&pattern).unwrap();
             assert_eq!(actual_pattern, expected_pattern);
             assert_eq!(actual_position, expected_position);
         }
@@ -825,11 +830,11 @@ mod tests {
     }
 
     #[test]
-    fn extract_regex_no_pattern() {
+    fn extract_pattern_no_pattern() {
         #[track_caller]
-        fn check_no_pattern(regex_str: &str, stage: Stage) {
+        fn check_no_pattern(pattern_str: &str, stage: Stage) {
             assert_eq!(
-                MusicTypeDisplay::pattern(&Regex::parse(regex_str, stage)),
+                MusicTypeDisplay::pattern(&Pattern::parse(pattern_str, stage)),
                 None
             );
         }

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -1,5 +1,4 @@
 use std::{
-    cmp::Ordering,
     collections::HashMap,
     fmt::Write,
     ops::{self, Deref},
@@ -451,9 +450,10 @@ impl Spec {
                 // For every handbell pair, we need patterns for `*<left><right>` and `*<right><left>`
                 for (b1, b2) in [(left_bell, right_bell), (right_bell, left_bell)] {
                     let pattern =
-                        Pattern::from_elems([Elem::Star, Elem::Bell(b1), Elem::Bell(b2)], stage);
+                        Pattern::from_elems([Elem::Star, Elem::Bell(b1), Elem::Bell(b2)], stage)
+                            .expect("Handbell patterns should always be valid regexes");
                     let mask = Mask::from_pattern(&pattern)
-                        .expect("Handbell patterns should always be valid");
+                        .expect("Handbell patterns should only have one `*`");
                     add_ch_pattern(&mask, self.handbell_coursing_weight);
                 }
             }
@@ -727,38 +727,7 @@ fn mask_parse_error(
     string: &str,
     e: bellframe::mask::ParseError,
 ) -> anyhow::Error {
-    use bellframe::mask::ParseError as PE;
-    let mut s = format!("Can't parse {} {:?}: ", mask_kind, string);
-    match e {
-        PE::MultipleStars => {
-            s.push_str("too many `*`s.  Masks can only have one region with `x` or `*`.");
-        }
-        PE::BellExceedsStage(bell, stage) => {
-            write!(s, "bell {} is out of stage {}", bell, stage).unwrap();
-        }
-        PE::MismatchedLength(len, stage) => match len.cmp(&stage.num_bells()) {
-            Ordering::Less => write!(
-                s,
-                "mask is too short; did you mean `{}*` or `{}{}`?",
-                string,
-                string,
-                stage
-                    .bells()
-                    .skip(len)
-                    .map(|b| b.to_char().unwrap())
-                    .collect::<String>()
-            )
-            .unwrap(),
-            Ordering::Equal => unreachable!(),
-            Ordering::Greater => write!(
-                s,
-                "mask is too long, needing at least {} bells (too many for {})",
-                len, stage
-            )
-            .unwrap(),
-        },
-    }
-    anyhow::Error::msg(s)
+    anyhow::Error::msg(format!("Can't parse {} {:?}: {}", mask_kind, string, e))
 }
 
 /////////////

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -10,7 +10,7 @@ use std::{
 use bellframe::{
     method::LABEL_LEAD_END,
     method_lib::QueryError,
-    music::{Regex, RegexElem},
+    music::{Elem, Pattern},
     place_not::PnBlockParseError,
     Bell, Mask, MethodLib, Row, RowBuf, Stage, Stroke,
 };
@@ -450,12 +450,10 @@ impl Spec {
                 let left_bell = right_bell + 1;
                 // For every handbell pair, we need patterns for `*<left><right>` and `*<right><left>`
                 for (b1, b2) in [(left_bell, right_bell), (right_bell, left_bell)] {
-                    let regex = Regex::from_elems(
-                        [RegexElem::Glob, RegexElem::Bell(b1), RegexElem::Bell(b2)],
-                        stage,
-                    );
-                    let mask =
-                        Mask::from_regex(&regex).expect("Handbell patterns should always be valid");
+                    let pattern =
+                        Pattern::from_elems([Elem::Star, Elem::Bell(b1), Elem::Bell(b2)], stage);
+                    let mask = Mask::from_pattern(&pattern)
+                        .expect("Handbell patterns should always be valid");
                     add_ch_pattern(&mask, self.handbell_coursing_weight);
                 }
             }
@@ -732,7 +730,7 @@ fn mask_parse_error(
     use bellframe::mask::ParseError as PE;
     let mut s = format!("Can't parse {} {:?}: ", mask_kind, string);
     match e {
-        PE::MultipleGlobs => {
+        PE::MultipleStars => {
             s.push_str("too many `*`s.  Masks can only have one region with `x` or `*`.");
         }
         PE::BellExceedsStage(bell, stage) => {

--- a/monument/lib/src/layout/new/utils.rs
+++ b/monument/lib/src/layout/new/utils.rs
@@ -78,7 +78,7 @@ fn add_fixed_bells_to_method(method: &mut super::Method, fixed_bells: &[Bell]) {
     'mask_loop: for mut ch_mask in method.ch_masks.iter().cloned() {
         // Attempt to add the fixed bells to this mask
         for &b in fixed_bells {
-            if let Err(BellAlreadySet) = ch_mask.mask.fix(b) {
+            if let Err(BellAlreadySet(_)) = ch_mask.mask.fix(b) {
                 // If a bell is known to be fixed in its home position but a mask requires it to be
                 // outside of its home position, then that mask will never be satisfied and can be
                 // removed.  For example, this would remove `x1xxx...` as a course head in Surprise

--- a/monument/lib/src/music.rs
+++ b/monument/lib/src/music.rs
@@ -87,7 +87,9 @@ impl Breakdown {
                 if ty.strokes.contains(start_stroke.offset(idx)) {
                     // ... count the number of instances of that type of music
                     for pattern in &ty.patterns {
-                        if pattern.matches(&temp_row) {
+                        // Unwrap is safe because `pattern` must have the same `Stage` as the rest
+                        // of the rows
+                        if pattern.matches(&temp_row).unwrap() {
                             *num_instances += 1;
                         }
                     }

--- a/monument/lib/src/music.rs
+++ b/monument/lib/src/music.rs
@@ -7,7 +7,7 @@ use crate::{
     utils::{Counts, OptRange},
     MusicTypeIdx, MusicTypeVec,
 };
-use bellframe::{music::Regex, Row, RowBuf, Stage, Stroke};
+use bellframe::{music::Pattern, Row, RowBuf, Stage, Stroke};
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use serde::Deserialize;
@@ -17,7 +17,7 @@ pub type Score = OrderedFloat<f32>;
 /// A class of music that Monument should care about
 #[derive(Debug, Clone)]
 pub struct MusicType {
-    pub regexes: Vec<Regex>,
+    pub patterns: Vec<Pattern>,
     pub strokes: StrokeSet,
 
     pub weight: Score,
@@ -27,13 +27,13 @@ pub struct MusicType {
 
 impl MusicType {
     pub fn new(
-        regexes: Vec<Regex>,
+        patterns: Vec<Pattern>,
         stroke_set: StrokeSet,
         weight: f32,
         count_range: OptRange,
     ) -> Self {
         Self {
-            regexes,
+            patterns,
             weight: OrderedFloat(weight),
             count_range,
             non_duffer: false, // TODO: Implement non-duffers properly
@@ -45,7 +45,7 @@ impl MusicType {
     /// computation caused `usize` to overflow.
     pub fn max_count(&self) -> Option<usize> {
         let mut sum = 0;
-        for r in &self.regexes {
+        for r in &self.patterns {
             sum += r.num_matching_rows()?;
         }
         Some(sum)
@@ -86,8 +86,8 @@ impl Breakdown {
             for (num_instances, ty) in occurences.iter_mut().zip_eq(music_types) {
                 if ty.strokes.contains(start_stroke.offset(idx)) {
                     // ... count the number of instances of that type of music
-                    for regex in &ty.regexes {
-                        if regex.matches(&temp_row) {
+                    for pattern in &ty.patterns {
+                        if pattern.matches(&temp_row) {
                             *num_instances += 1;
                         }
                     }


### PR DESCRIPTION
Makes `bellframe::music::Pattern` much more robust.