### PR TITLE
Bump `path-slash` to `0.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,9 +803,9 @@ checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "path-slash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498a099351efa4becc6a19c72aa9270598e8fd274ca47052e37455241c88b696"
+checksum = "c54014ba3c1880122928735226f78b6f5bf5bd1fed15e41e92cf7aa20278ce28"
 
 [[package]]
 name = "percent-encoding"

--- a/monument/cli/Cargo.toml
+++ b/monument/cli/Cargo.toml
@@ -28,7 +28,7 @@ toml = "0.5"
 [dev-dependencies]
 goldilocks-json-fmt = "0.2"
 ordered-float = { version = "3.0", features = ["serde"] }
-path-slash = "0.1"
+path-slash = "0.2"
 pulldown-cmark = "0.9"
 rayon = "1.5"
 regex = "1.5"

--- a/monument/test/src/common.rs
+++ b/monument/test/src/common.rs
@@ -725,7 +725,7 @@ impl CaseSource {
     /// (if the same file contains many test cases).
     fn name(&self) -> String {
         match &self {
-            Self::TomlFile(path) => path.to_slash_lossy(),
+            Self::TomlFile(path) => path.to_slash_lossy().into_owned(),
             Self::SectionOfFile {
                 file_path,
                 section_name,


### PR DESCRIPTION
Like #106 but also fixes the compilation errors.