### PR TITLE
Fully use `{Total,PerPart}Length` instead of `usize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 ### Monument
+- (#110) Exclusively use `{Total,PerPart}Length` to refer to lengths (as opposed to `usize`), thus
+    allowing the compiler to spot when we mix them up.
 - (#109) Encapsulate all the part-head logic into `PartHeadGroup`/`PartHead`/`PhRotation`.
 
 ---

--- a/monument/cli/src/lib.rs
+++ b/monument/cli/src/lib.rs
@@ -363,7 +363,13 @@ struct CompPrinter {
 impl CompPrinter {
     fn new(query: Arc<Query>) -> Self {
         Self {
-            length_width: query.len_range.end.saturating_sub(1).to_string().len(),
+            length_width: query
+                .len_range
+                .end
+                .as_usize()
+                .saturating_sub(1)
+                .to_string()
+                .len(),
             method_counts: query
                 .methods
                 .iter()

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     fmt::Write,
-    ops::{self, Deref},
+    ops::{self, Deref, Range},
     path::PathBuf,
     time::Duration,
 };
@@ -16,8 +16,9 @@ use bellframe::{
 use colored::Colorize;
 use itertools::Itertools;
 use monument::{
-    music::MusicType, utils::group::PartHeadGroup, Call, CallDisplayStyle, CallVec, MethodVec,
-    MusicTypeVec, OptRange, Query, SpliceStyle,
+    music::MusicType,
+    utils::{group::PartHeadGroup, TotalLength},
+    Call, CallDisplayStyle, CallVec, MethodVec, MusicTypeVec, OptRange, Query, SpliceStyle,
 };
 use serde::Deserialize;
 
@@ -260,7 +261,10 @@ impl Spec {
 
         // Build this layout into a `Graph`
         Ok(Query {
-            len_range: self.length.range.clone(),
+            len_range: Range {
+                start: TotalLength::new(self.length.range.start),
+                end: TotalLength::new(self.length.range.end),
+            },
             num_comps: self.num_comps,
             allow_false: self.allow_false,
             stage,
@@ -279,7 +283,7 @@ impl Spec {
             music_types,
             music_displays,
             start_stroke: self.start_stroke,
-            max_duffer_rows: self.max_duffer_rows,
+            max_duffer_rows: self.max_duffer_rows.map(TotalLength::new),
         })
     }
 

--- a/monument/lib/src/graph/falseness.rs
+++ b/monument/lib/src/graph/falseness.rs
@@ -98,9 +98,9 @@ impl FalsenessTable {
         // This is useful because falseness can exist between two rows **only** if their 'group'
         // masks are compatible.  For example, any rows of the form `xx1xx8x7` can't be false
         // against a row of the form `x1xxx8x7` because the treble can't be in two places at once.
-        // false chunk transposition tables are quadratic in the sizes of the rows we have to
-        // cross-product together, so it is extremely worthwhile to split large groups of rows into
-        // many smaller groups which can be computed independently.
+        // The time needed to compute falseness tables is quadratic in the sizes of the rows we
+        // have to cross-product together, so it is extremely worthwhile to split large groups of
+        // rows into many smaller groups which can be computed independently.
         //
         // In this loop, we also check for `ChunkRange`s which are 'self-false' (i.e. include some
         // row multiple times).
@@ -117,7 +117,7 @@ impl FalsenessTable {
 
             let mut rows_so_far = HashSet::<&Row>::new();
             let mut row_groups_for_this_range: RowGroups = HashMap::new();
-            for offset in 0..range.len.0 {
+            for offset in 0..range.len.as_usize() {
                 let row_index = (range.start.sub_lead_idx + offset) % plain_course.len();
                 let row = plain_course.get_row(row_index).unwrap();
                 // Check for self-falseness.  I.e. if some row is repeated twice within a chunk,
@@ -278,7 +278,7 @@ impl Debug for ChunkRange {
         write!(
             f,
             "ChunkRange({:?},{}+{})",
-            self.start.method, self.start.sub_lead_idx, self.len.0
+            self.start.method, self.start.sub_lead_idx, self.len
         )
     }
 }

--- a/monument/lib/src/search/mod.rs
+++ b/monument/lib/src/search/mod.rs
@@ -10,7 +10,7 @@ use std::{
 
 use itertools::Itertools;
 
-use crate::{Progress, Query, QueryUpdate};
+use crate::{utils::TotalLength, Progress, Query, QueryUpdate};
 
 mod graph;
 mod prefix;
@@ -91,10 +91,10 @@ fn send_progress_update(
     iter_count: usize,
     num_comps: usize,
 ) {
-    let mut total_len = 0;
-    let mut max_length = 0;
+    let mut total_len = TotalLength::ZERO;
+    let mut max_length = TotalLength::ZERO;
     frontier.iter().for_each(|n| {
-        total_len += n.length() as usize;
+        total_len += n.length();
         max_length = max_length.max(n.length());
     });
     update_channel
@@ -102,7 +102,7 @@ fn send_progress_update(
             iter_count,
             num_comps,
             queue_len: frontier.len(),
-            avg_length: total_len as f32 / frontier.len() as f32,
+            avg_length: total_len.as_usize() as f32 / frontier.len() as f32,
             max_length,
         }))
         .unwrap();

--- a/monument/lib/src/utils/lengths.rs
+++ b/monument/lib/src/utils/lengths.rs
@@ -1,0 +1,73 @@
+use std::ops::{Add, AddAssign, Sub, SubAssign};
+
+use super::group::PartHeadGroup;
+
+/// A length **in one part** of the composition.  This and [`TotalLength`] allow the compiler to
+/// disallow mixing up the different definitions of 'length'.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct PerPartLength(u32);
+
+/// The combined length **across all parts**.  This and [`PerPartLength`] allow the compiler to
+/// disallow mixing up the different definitions of 'length'.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TotalLength(u32);
+
+impl PerPartLength {
+    pub fn as_total(self, part_heads: &PartHeadGroup) -> TotalLength {
+        TotalLength(self.0 * part_heads.size() as u32)
+    }
+}
+
+macro_rules! impl_length {
+    ($name: ident) => {
+        impl $name {
+            pub const ZERO: Self = Self(0);
+
+            pub fn new(l: usize) -> Self {
+                Self(l as u32)
+            }
+
+            pub fn as_usize(self) -> usize {
+                self.0 as usize
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl Sub for $name {
+            type Output = Self;
+
+            fn sub(self, rhs: Self) -> Self {
+                Self(self.0 - rhs.0)
+            }
+        }
+
+        impl SubAssign for $name {
+            fn sub_assign(&mut self, rhs: Self) {
+                self.0 -= rhs.0
+            }
+        }
+
+        impl Add for $name {
+            type Output = Self;
+
+            fn add(self, rhs: Self) -> Self {
+                Self(self.0 + rhs.0)
+            }
+        }
+
+        impl AddAssign for $name {
+            fn add_assign(&mut self, rhs: Self) {
+                self.0 += rhs.0
+            }
+        }
+    };
+}
+
+impl_length!(PerPartLength);
+impl_length!(TotalLength);

--- a/monument/lib/src/utils/mod.rs
+++ b/monument/lib/src/utils/mod.rs
@@ -5,8 +5,10 @@ use serde::Deserialize;
 
 mod counts;
 pub mod group;
+mod lengths;
 
 pub use counts::Counts;
+pub use lengths::{PerPartLength, TotalLength};
 
 /// An inclusive range where each side is optionally bounded.  This is essentially a combination of
 /// [`RangeInclusive`](std::ops::RangeInclusive) (`min..=max`),
@@ -62,32 +64,32 @@ pub fn default_shorthands<'s>(
 
 /// A container type which sorts its contents according to some given distance metric
 #[derive(Debug, Clone)]
-pub struct FrontierItem<T> {
-    pub item: T,
-    pub distance: usize,
+pub struct FrontierItem<Item, Dist> {
+    pub item: Item,
+    pub distance: Dist,
 }
 
-impl<T> FrontierItem<T> {
-    pub fn new(item: T, distance: usize) -> Self {
+impl<Item, Dist> FrontierItem<Item, Dist> {
+    pub fn new(item: Item, distance: Dist) -> Self {
         Self { item, distance }
     }
 }
 
-impl<T> PartialEq for FrontierItem<T> {
+impl<Item, Dist: PartialEq> PartialEq for FrontierItem<Item, Dist> {
     fn eq(&self, other: &Self) -> bool {
         self.distance == other.distance
     }
 }
 
-impl<T> Eq for FrontierItem<T> {}
+impl<Item, Dist: Eq> Eq for FrontierItem<Item, Dist> {}
 
-impl<T> PartialOrd for FrontierItem<T> {
+impl<Item, Dist: Ord> PartialOrd for FrontierItem<Item, Dist> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<T> Ord for FrontierItem<T> {
+impl<Item, Dist: Ord> Ord for FrontierItem<Item, Dist> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.distance.cmp(&other.distance)
     }

--- a/monument/test/src/common.rs
+++ b/monument/test/src/common.rs
@@ -842,7 +842,7 @@ impl Comp {
 impl Comp {
     fn new(source: &monument::Comp, query: &monument::Query) -> Self {
         Self {
-            length: source.length,
+            length: source.length.as_usize(),
             string: source.call_string(query),
             avg_score: Self::round_score(source.avg_score.0),
             // Only store part heads for multi-part strings


### PR DESCRIPTION
Thus, we get the type checker to stop us mixing the two meanings of 'length'.