### PR TITLE
Rationalise use of `unsafe` code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - (#109) Encapsulate all the part-head logic into `PartHeadGroup`/`PartHead`/`PhRotation`.
 
 ### BellFrame
+- (#117) Rationalise the use of `unsafe` in `bellframe`.
 - (#115) Remove unnecessary `unsafe` in `bellframe::music`.
 - (#115) Fix integer underflow when computing internal runs.
 - (#115) Implement `Ord` for `Mask`

--- a/bellframe/src/mask.rs
+++ b/bellframe/src/mask.rs
@@ -100,7 +100,8 @@ impl Mask {
     pub fn fix_bells(stage: Stage, fixed_bells: impl IntoIterator<Item = Bell>) -> Self {
         let mut new_mask = Self::empty(stage);
         for b in fixed_bells {
-            // Unsafety is OK because bells are only ever fixed to their own locations
+            // SAFETY: bells are only ever fixed to their own locations, so can't be fixed in two
+            // different locations
             unsafe { new_mask.fix_unchecked(b) };
         }
         new_mask
@@ -185,8 +186,7 @@ impl Mask {
             Some(p) if p == place => Ok(()), // Bell is already fixed here, so nothing to do
             Some(_) => Err(BellAlreadySet(bell)), // Adding the bell would fix it twice
             None => {
-                // Unsafety is OK because this match arm only executes if the bell isn't fixed in
-                // `self`
+                // SAFETY: because this match arm only executes if `bell` isn't fixed in `self`
                 unsafe { self.set_bell_unchecked(bell, place) };
                 Ok(())
             }
@@ -210,8 +210,8 @@ impl Mask {
     /// If this mask matches exactly one [`Row`], then return that [`Row`] (otherwise `None`).
     pub fn as_row(&self) -> Option<RowBuf> {
         if self.bells.iter().all(Option::is_some) {
-            // This unsafety is OK because we assert an invariant that masks are subsets of rows
-            // (and thus a complete mask satisfies all the invariants of rows).
+            // SAFETY: The invariants of `self.bells` a superset of those of `Row`s, so a complete
+            // `Mask` satisfies all the invariants of `Row` and `RowBuf`.
             Some(unsafe { RowBuf::from_bell_iter_unchecked(self.bells.iter().map(|b| b.unwrap())) })
         } else {
             None

--- a/bellframe/src/music.rs
+++ b/bellframe/src/music.rs
@@ -138,7 +138,7 @@ impl Pattern {
             return Err(PatternError::TooShort(num_non_stars, stage, string)); // Too short
         }
 
-        // Unsafety is OK because `elems` has been normalised
+        // SAFETY: `elems` has been normalised
         Ok(unsafe { Self::from_vec_unchecked(elems, stage) })
     }
 
@@ -146,8 +146,8 @@ impl Pattern {
     ///
     /// # Safety
     ///
-    /// See [`Pattern::from_vec_unchecked`] for safety requirements.
-    /// [`Pattern::from_vec_unchecked`] is called after collecting the [`Iterator`] into a [`Vec`].
+    /// Safe if `iter.collect::<Vec<_>>()` satisfies the safety conditions of
+    /// [`Pattern::from_vec_unchecked`].
     pub unsafe fn from_elems_unchecked(iter: impl IntoIterator<Item = Elem>, stage: Stage) -> Self {
         Self::from_vec_unchecked(iter.into_iter().collect_vec(), stage)
     }
@@ -471,7 +471,7 @@ impl Pattern {
                     None => return Ok(true),
                     // Because of normalisation, a star cannot be followed by anything other than a
                     // bell (or the end of the pattern).  This branch should only be reachable with
-                    // `unsafe`
+                    // incorrect use of `unsafe`
                     _ => unreachable!(),
                 },
                 // If we've run out of pattern elements, then the row matches iff we also run out of

--- a/bellframe/src/row/accumulator.rs
+++ b/bellframe/src/row/accumulator.rs
@@ -28,7 +28,7 @@ impl RowAccumulator {
 
     /// Performs `self = self * row`
     #[inline]
-    pub fn accumulate(&mut self, row: &Row) -> Result<(), IncompatibleStages> {
+    pub fn post_accumulate(&mut self, row: &Row) -> Result<(), IncompatibleStages> {
         self.total.mul_into(row, &mut self.temp_row)?; // Multiply `total` into `temp_row`
         std::mem::swap(&mut self.total, &mut self.temp_row); // Swap the result back into `total`
         Ok(())
@@ -40,7 +40,7 @@ impl RowAccumulator {
     ///
     /// This is safe if `row.stage() == self.stage()`.
     #[inline]
-    pub unsafe fn accumulate_unchecked(&mut self, row: &Row) {
+    pub unsafe fn post_accumulate_unchecked(&mut self, row: &Row) {
         self.total.mul_into_unchecked(row, &mut self.temp_row); // Multiply `total` into `temp_row`
         std::mem::swap(&mut self.total, &mut self.temp_row); // Swap the result back into `total`
     }
@@ -86,13 +86,13 @@ impl RowAccumulator {
 impl MulAssign<&Row> for RowAccumulator {
     #[inline]
     fn mul_assign(&mut self, rhs: &Row) {
-        self.accumulate(rhs).unwrap()
+        self.post_accumulate(rhs).unwrap()
     }
 }
 
 impl MulAssign<&RowBuf> for RowAccumulator {
     #[inline]
     fn mul_assign(&mut self, rhs: &RowBuf) {
-        self.accumulate(rhs).unwrap()
+        self.post_accumulate(rhs).unwrap()
     }
 }

--- a/bellframe/src/row/owned.rs
+++ b/bellframe/src/row/owned.rs
@@ -101,7 +101,7 @@ impl RowBuf {
     /// assert_eq!(RowBuf::rounds(Stage::CATERS).to_string(), "123456789");
     /// ```
     pub fn rounds(stage: Stage) -> Self {
-        // This unsafety is OK, because rounds is always a valid `Row`
+        // SAFETY: rounds is a valid `Row` on any stage
         unsafe { Self::from_bell_iter_unchecked(stage.bells()) }
     }
 
@@ -115,7 +115,7 @@ impl RowBuf {
     /// assert_eq!(RowBuf::backrounds(Stage::CATERS).to_string(), "987654321");
     /// ```
     pub fn backrounds(stage: Stage) -> Self {
-        // This unsafety is OK, because backrounds is always a valid `Row`
+        // SAFETY: backrounds is always a valid `Row`
         unsafe { Self::from_bell_iter_unchecked(stage.bells().rev()) }
     }
 
@@ -131,7 +131,7 @@ impl RowBuf {
     pub fn queens(stage: Stage) -> Self {
         let odds = stage.bells().step_by(2);
         let evens = stage.bells().skip(1).step_by(2);
-        // This unsafety is OK, because Queens is always a valid `Row`
+        // SAFETY: Queens is always a valid `Row`
         unsafe { Self::from_bell_iter_unchecked(odds.chain(evens)) }
     }
 
@@ -199,8 +199,7 @@ impl RowBuf {
     ///     "4213"
     /// );
     /// // Converting a `Row` from an invalid `Vec` of `Bell`s compiles and runs,
-    /// // but silently creates an invalid `Row` and, by extension, silently causes
-    /// // undefined behaviour
+    /// // but silently creates an invalid `Row` and silently causes undefined behaviour
     /// assert_eq!(
     ///     unsafe {
     ///         RowBuf::from_vec_unchecked(vec![
@@ -266,7 +265,7 @@ impl RowBuf {
     /// let row = unsafe { RowBuf::from_bell_iter_unchecked(iter) };
     /// assert_eq!(row.to_string(), "14532");
     /// // Create an invalid row from an iterator over `Bell`s.  We get no error,
-    /// // but doing anything with the resulting `Row` is undefined behaviour
+    /// // but instead we get silent Undefined Behaviour
     /// let iter = [0, 3, 7, 2, 1].iter().copied().map(Bell::from_index);
     /// let row = unsafe { RowBuf::from_bell_iter_unchecked(iter) };
     /// assert_eq!(row.to_string(), "14832");
@@ -329,8 +328,8 @@ impl RowBuf {
         let cover_bells = stage.bells().skip(bells.len());
         bells.extend(cover_bells);
 
-        // This unsafety is OK because we have verified that `bells` corresponds to a `Row`, while
-        // the no-zero-stage invariant makes sure that `bells` is non-empty
+        // SAFETY: we have verified that `bells` corresponds to a `Row`, while the no-zero-stage
+        // invariant makes sure that `bells` is non-empty
         let mut row = unsafe { Self::from_vec_unchecked(bells) };
         row.extend_to_stage(stage);
         Ok(row)
@@ -346,8 +345,8 @@ impl RowBuf {
     /// inference.
     #[inline]
     pub fn as_row(&self) -> &Row {
-        // This unsafety is OK, because `RowBuf` requires its bells to form a valid row according
-        // to the Framework
+        // SAFETY: By definition, `RowBuf` requires its bells to form a valid row according to the
+        // Framework
         unsafe { Row::from_slice_unchecked(&self.bell_vec) }
     }
 
@@ -355,8 +354,8 @@ impl RowBuf {
     /// inference.
     #[inline]
     pub fn as_mut_row(&mut self) -> &mut Row {
-        // This unsafety is OK, because `RowBuf` requires its bells to form a valid row according
-        // to the Framework
+        // SAFETY: By definition, `RowBuf` requires its bells to form a valid row according to the
+        // Framework
         unsafe { Row::from_mut_slice_unchecked(&mut self.bell_vec) }
     }
 
@@ -390,9 +389,7 @@ impl Deref for RowBuf {
 impl DerefMut for RowBuf {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        // This unsafety is OK because the slice of `Bell`s comes from a `RowBuf`, which must
-        // represent a valid row
-        unsafe { Row::from_mut_slice_unchecked(&mut self.bell_vec) }
+        self.as_mut_row()
     }
 }
 

--- a/bellframe/src/stage.rs
+++ b/bellframe/src/stage.rs
@@ -18,7 +18,7 @@ use crate::{RowBuf, SameStageVec};
 use crate::{Bell, Method, Row};
 
 /// A newtype over [`u8`] that represents a stage.  All `Stage`s must contain at least one
-/// [`Bell`]; zero-bell `Stage`s cannot be created without `unsafe` code.
+/// [`Bell`]; zero-bell `Stage`s cannot be created without using incorrect `unsafe` code.
 ///
 /// To create a new `Stage`, you can either create it directly with [`Stage::try_from`] (which
 /// returns a [`Result`]) or with [`Stage::new`] (which panics if passed `0`).
@@ -216,8 +216,7 @@ impl Stage {
                 new_extent_bell_vec.extend_from_slice(bells_after)
             }
         }
-        // Unsafety is OK because we generated the rows by inserting the new tenor into an already
-        // known-good row.
+        // SAFETY: We generated the rows by inserting the new tenor into an already valid `Row`.
         unsafe { SameStageVec::from_bell_vec_unchecked(new_extent_bell_vec, self) }
     }
 }

--- a/monument/cli/src/calls.rs
+++ b/monument/cli/src/calls.rs
@@ -25,10 +25,7 @@ impl BaseCalls {
         bob_weight: Option<f32>,
         single_weight: Option<f32>,
     ) -> anyhow::Result<CallVec<Call>> {
-        // Panic if the comp has less than 4 bells.  I don't expect anyone to use Monument to
-        // generate comps on fewer than 8 bells, but we should still check because otherwise the
-        // `unsafe` code causes undefined behaviour
-        assert!(stage >= Stage::MINIMUS);
+        assert!(stage >= Stage::MINIMUS); // Calls aren't defined on < 4 bells
 
         let (mut bob, mut single) = match self {
             BaseCalls::None => return Ok(CallVec::new()),
@@ -39,16 +36,10 @@ impl BaseCalls {
             BaseCalls::Far => {
                 let n = stage.num_bells_u8();
                 (
-                    // The unsafety here is OK, because the slice is always sorted (unless stage <
-                    // MINIMUS, in which case the assert trips)
-                    lead_end_bob(unsafe {
-                        PlaceNot::from_sorted_slice(&[0, n - 3], stage).unwrap()
-                    }),
-                    // The unsafety here is OK, because the slice is always sorted (unless stage <
-                    // MINIMUS, in which case the assert trips)
-                    lead_end_single(unsafe {
-                        PlaceNot::from_sorted_slice(&[0, n - 3, n - 2, n - 1], stage).unwrap()
-                    }),
+                    lead_end_bob(PlaceNot::from_slice(&mut [0, n - 3], stage).unwrap()),
+                    lead_end_single(
+                        PlaceNot::from_slice(&mut [0, n - 3, n - 2, n - 1], stage).unwrap(),
+                    ),
                 )
             }
         };


### PR DESCRIPTION
This goes through the `unsafe` code and either removes or validates each use of `unsafe`.  The `unsafe` is now entirely contained in `bellframe`; Monument is completely safe.