### PR TITLE
Correct `Display` options for `{Total,PerPart}Length`

### DIFF
--- a/monument/lib/src/utils/lengths.rs
+++ b/monument/lib/src/utils/lengths.rs
@@ -42,7 +42,7 @@ macro_rules! impl_length {
 
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(f, "{}", self.0)
+                std::fmt::Display::fmt(&self.0, f)
             }
         }
 


### PR DESCRIPTION
Previously `{Total,PerPart}Length`s wouldn't respect options like padding/alignment, causing the output columns to end up misaligned.