### PR TITLE
Limits in toml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 ### Monument
+- (#120) Allow `queue_limit` and `graph_size_limit` to be set in the TOML format.
 - (#116) Much smarter way of determining default method balance.  (Nerdy details:) Method counts are
     weighted by the square root of each method's lead length (so shorter methods won't need as many
     rows), and will round 'outwards' for cases like cyclic spliced where a 'perfect' method balance

--- a/monument/cli/guide.md
+++ b/monument/cli/guide.md
@@ -157,6 +157,8 @@ take you to more in-depth docs about it.
 - [`length`](#length-required)
 - [`num_comps = 100`](#num_comps)
 - [`allow_false = false`](#allow_false)
+- [`queue_limit`](#queue_limit)
+- [`graph_size_limit`](#graph_size_limit)
 
 **Methods:**
 - [`method`](#method)
@@ -225,6 +227,19 @@ The number of compositions you want.  Defaults to `100`
 
 If `true`, Monument will ignore falseness and generate potentially false compositions.  Defaults to
 `false`.
+
+#### `queue_limit`
+
+**_(since v0.11.0)_**
+
+Sets a limit on the number of compositions that Monument will consider at any time.  Monument's
+memory usage is proportional to this queue's length.  Defaults to 10 million.
+
+#### `graph_size_limit`
+
+**_(since v0.11.0)_**
+
+Sets a limit on the number of chunks in the composition graph.  Defaults to 100,000.
 
 ### Methods
 
@@ -507,7 +522,9 @@ patterns = [
 ```
 Defaults to 0.
 
-#### `leadwise` _(removed in v0.10.0)_
+#### `leadwise`
+
+**_(removed in v0.10.0)_**
 
 If set, this will stop Monument using calling positions, and instead label all the calls
 positionally.  `course_heads`, `split_tenors` and `ch_weights` will obviously have no effect, and
@@ -519,7 +536,9 @@ this is for weird cases like differential methods, which don't have a well-defin
 
 ### Starts/Ends
 
-#### `start_row` and `end_row` _(since v0.10.0)_
+#### `start_row` and `end_row`
+
+**_(since v0.10.0)_**
 
 Specifies the row used to start or finish the composition, both defaulting to rounds.  These don't
 work with multi-parts, but are useful for things like getting Monument to extend 720s of Minor into

--- a/monument/cli/src/args.rs
+++ b/monument/cli/src/args.rs
@@ -1,0 +1,63 @@
+use std::path::PathBuf;
+
+use log::LevelFilter;
+use structopt::StructOpt;
+
+use crate::DebugOption;
+
+/// A struct storing the CLI args taken by Monument.  `StructOpt` will generate the argument
+/// parsing/help code for us.
+#[derive(Debug, Clone, StructOpt)]
+#[structopt(name = "Monument", about = "Fast and flexible composing engine")]
+pub struct CliArgs {
+    /// The name of the specification file for Monument (`*.toml`)
+    #[structopt(parse(from_os_str))]
+    pub input_file: PathBuf,
+
+    #[structopt(flatten)]
+    pub config: Options,
+
+    /// Makes Monument print more output (`-vv` will produce all output).
+    #[structopt(short, long = "verbose", parse(from_occurrences))]
+    pub verbosity: usize,
+    /// Makes Monument print less output (`-qq` will only produce errors).
+    #[structopt(short, long = "quiet", parse(from_occurrences))]
+    pub quietness: usize,
+}
+
+/// Parameters passed directly into `monument_cli::run`, used to generated the [`monument::Config`]
+/// for the search
+#[derive(Default, Debug, Clone, StructOpt)]
+pub struct Options {
+    /// The maximum number of threads that Monument will use.
+    // TODO: Uncomment this once multi-threading is possible
+    // #[structopt(short = "T", long)]
+    pub num_threads: Option<usize>,
+    /// The maximum number of chunks in the chunk graph.  Exceeding this during generation will
+    /// cause an error.  Defaults to 100K.
+    #[structopt(long)]
+    pub graph_size_limit: Option<usize>,
+    /// The maximum number of prefixes that Monument will store at once.  Defaults to 10 million.
+    #[structopt(short = "Q", long)]
+    pub queue_limit: Option<usize>,
+
+    /// Debug options.  `spec`, `query`, `layout` and `graph` print the corresponding data
+    /// structures.  `no-search` will run as normal but stop just before starting the full search.
+    #[structopt(short = "D", long)]
+    pub debug_option: Option<DebugOption>,
+}
+
+impl CliArgs {
+    /// Parse the `-q`/`-v` args into the [`LevelFilter`] to give to the `log` library
+    pub fn log_level(&self) -> LevelFilter {
+        match self.verbosity as isize - self.quietness as isize {
+            x if x < -2 => LevelFilter::Off, // -qqq (or more `q`s)
+            -2 => LevelFilter::Error,        // -qq
+            -1 => LevelFilter::Warn,         // -q
+            0 => LevelFilter::Info,          // <none of -q or -v>
+            1 => LevelFilter::Debug,         // -v
+            2 => LevelFilter::Trace,         // -vv
+            _ => LevelFilter::Trace,         // -vvv (or more `v`s)
+        }
+    }
+}

--- a/monument/cli/src/main.rs
+++ b/monument/cli/src/main.rs
@@ -1,26 +1,21 @@
 #![deny(clippy::all)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
-use std::path::PathBuf;
-
 use colored::Colorize;
-use log::LevelFilter;
-use monument::Config;
-use monument_cli::{CtrlCBehaviour, DebugOption};
+use monument_cli::{args::CliArgs, Environment, Source};
 use structopt::StructOpt;
 
 fn main() {
     let args = CliArgs::from_args();
     monument_cli::init_logging(args.log_level());
     let result = monument_cli::run(
-        monument_cli::Source::Path(args.input_file.clone()),
-        args.debug_option,
-        &args.config(),
-        CtrlCBehaviour::RecoverComps,
+        Source::Path(args.input_file.clone()),
+        &args.config,
+        Environment::Cli,
     );
     match result {
         Ok(Some(query_result)) => query_result.print(),
-        Ok(None) => assert!(args.debug_option.is_some()),
+        Ok(None) => assert!(args.config.debug_option.is_some()),
         Err(e) => {
             // In the case of an error, print the error message nicely then terminate the program
             // with code -1 without causing a panic message.
@@ -28,72 +23,5 @@ fn main() {
             drop(args);
             std::process::exit(-1);
         }
-    }
-}
-
-/// A struct storing the CLI args taken by Monument.  `StructOpt` will generate the argument
-/// parsing/help code for us.
-#[derive(Debug, Clone, StructOpt)]
-#[structopt(name = "Monument", about = "Fast and flexible composing engine")]
-struct CliArgs {
-    /// The name of the specification file for Monument (`*.toml`)
-    #[structopt(parse(from_os_str))]
-    input_file: PathBuf,
-
-    /// The maximum number of threads that Monument will use.
-    // TODO: Uncomment this once multi-threading is possible
-    // #[structopt(short = "T", long)]
-    num_threads: Option<usize>,
-    /// The maximum number of chunks in the chunk graph.  Exceeding this during generation will
-    /// cause an error.  Defaults to 100K.
-    #[structopt(long)]
-    graph_size_limit: Option<usize>,
-    /// The maximum number of prefixes that Monument will store at once.  Defaults to 10 million.
-    #[structopt(short = "Q", long)]
-    queue_limit: Option<usize>,
-
-    /// Makes Monument print more output (`-vv` will produce all output).
-    #[structopt(short, long = "verbose", parse(from_occurrences))]
-    verbosity: usize,
-    /// Makes Monument print less output (`-qq` will only produce errors).
-    #[structopt(short, long = "quiet", parse(from_occurrences))]
-    quietness: usize,
-
-    /// Debug options.  `spec`, `query`, `layout` and `graph` print the corresponding data
-    /// structures.  `no-search` will run as normal but stop just before starting the full search.
-    #[structopt(short = "D", long)]
-    debug_option: Option<DebugOption>,
-}
-
-impl CliArgs {
-    /// Parse the `-q`/`-v` args into the [`LevelFilter`] to give to the `log` library
-    fn log_level(&self) -> LevelFilter {
-        match self.verbosity as isize - self.quietness as isize {
-            x if x < -2 => LevelFilter::Off, // -qqq (or more `q`s)
-            -2 => LevelFilter::Error,        // -qq
-            -1 => LevelFilter::Warn,         // -q
-            0 => LevelFilter::Info,          // <none of -q or -v>
-            1 => LevelFilter::Debug,         // -v
-            2 => LevelFilter::Trace,         // -vv
-            _ => LevelFilter::Trace,         // -vvv (or more `v`s)
-        }
-    }
-
-    fn config(&self) -> Config {
-        let mut config = Config {
-            thread_limit: self.num_threads,
-            // Don't `drop` any of the search data structures, since Monument will exit shortly
-            // after the search terminates.  With the `Arc`-based data structures, this is
-            // seriously beneficial - it shaves many seconds off Monument's total running time.
-            mem_forget_search_data: true,
-            ..Config::default()
-        };
-        if let Some(q) = self.queue_limit {
-            config.queue_limit = q;
-        }
-        if let Some(g) = self.graph_size_limit {
-            config.graph_size_limit = g;
-        }
-        config
     }
 }

--- a/monument/lib/src/lib.rs
+++ b/monument/lib/src/lib.rs
@@ -182,7 +182,7 @@ pub struct Config {
     /// This massively improves the termination speed (because all individual allocations don't
     /// need to be freed), but only makes sense for the CLI, where Monument will do exactly one
     /// search run before terminating (thus returning the memory to the OS anyway).
-    pub mem_forget_search_data: bool,
+    pub leak_search_memory: bool,
 }
 
 impl Default for Config {
@@ -194,7 +194,7 @@ impl Default for Config {
             optimisation_passes: graph::optimise::passes::default(),
 
             queue_limit: 10_000_000,
-            mem_forget_search_data: false,
+            leak_search_memory: false,
         }
     }
 }

--- a/monument/lib/src/search/mod.rs
+++ b/monument/lib/src/search/mod.rs
@@ -93,7 +93,7 @@ pub(crate) fn search(
     // If we're running the CLI, then `mem::forget` the frontier to avoid tons of drop calls.  We
     // don't care about leaking because the Monument process is about to terminate and the OS will
     // clean up the memory anyway.
-    if config.mem_forget_search_data {
+    if config.leak_search_memory {
         std::mem::forget(search_data);
         std::mem::forget(frontier);
     }

--- a/monument/test/results.json
+++ b/monument/test/results.json
@@ -336,27 +336,12 @@
       { "length": 1344, "string": "#Y[-]LL[-]C[-]L[s]Y[s]", "avg_score": -0.03125, "part_head": "17823456" },
       { "length": 1344, "string": "#Y[-]LL[-]L[-]C[s]Y[s]", "avg_score": -0.03125, "part_head": "17823456" },
       { "length": 1344, "string": "#Y[-]LL[-]L[-]L[s]Y[s]", "avg_score": -0.03125, "part_head": "17823456" },
-      {
-        "length": 1344,
-        "string": "#C[s]Y[-]Y[s]Y[s]L[-]Y[s]",
-        "avg_score": -0.030212402,
-        "part_head": "13456782"
-      },
-      {
-        "length": 1344,
-        "string": "#C[s]Y[-]Y[s]Y[s]C[-]Y[s]",
-        "avg_score": -0.029449463,
-        "part_head": "13456782"
-      },
+      { "length": 1344, "string": "#C[s]Y[-]Y[s]Y[s]L[-]Y[s]", "avg_score": -0.030212402, "part_head": "13456782" },
+      { "length": 1344, "string": "#C[s]Y[-]Y[s]Y[s]C[-]Y[s]", "avg_score": -0.029449463, "part_head": "13456782" },
       { "length": 1344, "string": "#L[s]Y[-]Y[s]Y[s]L[-]Y[s]", "avg_score": -0.02722168, "part_head": "13456782" },
       { "length": 1344, "string": "#Y[-]Y[s]C[-]Y[-]Y[-]Y[s]", "avg_score": -0.02722168, "part_head": "18234567" },
       { "length": 1344, "string": "#Y[-]Y[s]L[-]Y[-]Y[-]Y[s]", "avg_score": -0.02722168, "part_head": "18234567" },
-      {
-        "length": 1344,
-        "string": "#L[s]Y[-]Y[s]Y[s]C[-]Y[s]",
-        "avg_score": -0.026489258,
-        "part_head": "13456782"
-      },
+      { "length": 1344, "string": "#L[s]Y[-]Y[s]Y[s]C[-]Y[s]", "avg_score": -0.026489258, "part_head": "13456782" },
       { "length": 1344, "string": "#Y[-]C[s]Y[-]Y[s]Y[-]Y", "avg_score": -0.020080566, "part_head": "18234567" },
       { "length": 1344, "string": "#Y[-]L[s]Y[-]Y[s]Y[-]Y", "avg_score": -0.020080566, "part_head": "18234567" },
       { "length": 1344, "string": "#Y[s]C[s]YY[s]Y[s]Y[-]", "avg_score": -0.016357422, "part_head": "18234567" },
@@ -904,9 +889,7 @@
       { "length": 194, "string": "sWMB>", "avg_score": -0.030426025 }
     ]
   },
-  "test/cases/false-course-3.toml": {
-    "comps": [{ "length": 192, "string": "sTsWsMsBsVsH", "avg_score": -0.09375 }]
-  },
+  "test/cases/false-course-3.toml": { "comps": [{ "length": 192, "string": "sTsWsMsBsVsH", "avg_score": -0.09375 }] },
   "test/cases/false-splice.toml": {
     "comps": [
       { "length": 290, "string": "L[W]BBB[M]B[sM]L[sH]L[sW]BBL>", "avg_score": 0.04309082 },
@@ -2269,9 +2252,7 @@
       { "length": 448, "string": "#PLLL[-]P[-]L", "avg_score": 0.12454224, "part_head": "17823456" }
     ]
   },
-  "test/cases/inclusive-method-count.toml": {
-    "comps": [{ "length": 224, "string": "", "avg_score": 0.25894165 }]
-  },
+  "test/cases/inclusive-method-count.toml": { "comps": [{ "length": 224, "string": "", "avg_score": 0.25894165 }] },
   "test/cases/little-bob-shorthand.toml": {
     "comps": [
       { "length": 48, "string": "LLLPL", "avg_score": 0.5 },
@@ -2308,12 +2289,7 @@
   },
   "test/cases/multipart-multiple-start-ends-1.toml": {
     "comps": [
-      {
-        "length": 672,
-        "string": "<BB[H]BB[M]B[M]B[sM]Y[sW]B>",
-        "avg_score": 0.034240723,
-        "part_head": "14235678"
-      },
+      { "length": 672, "string": "<BB[H]BB[M]B[M]B[sM]Y[sW]B>", "avg_score": 0.034240723, "part_head": "14235678" },
       { "length": 576, "string": "<BB[H]BB[sM]B[M]Y[sW]B>", "avg_score": 0.045837402, "part_head": "14235678" },
       { "length": 672, "string": "BB[M]B[M]B[sM]Y[W]B[sW]B", "avg_score": 0.05505371, "part_head": "13425678" },
       { "length": 672, "string": "BB[sM]B[M]Y[sW]B[W]B[W]B", "avg_score": 0.059509277, "part_head": "13425678" },
@@ -2332,12 +2308,7 @@
   },
   "test/cases/multipart-multiple-start-ends-2.toml": {
     "comps": [
-      {
-        "length": 672,
-        "string": "<BB[H]BB[M]B[M]B[sM]Y[sW]B>",
-        "avg_score": 0.034240723,
-        "part_head": "14235678"
-      },
+      { "length": 672, "string": "<BB[H]BB[M]B[M]B[sM]Y[sW]B>", "avg_score": 0.034240723, "part_head": "14235678" },
       { "length": 576, "string": "<BB[H]BB[sM]B[M]Y[sW]B>", "avg_score": 0.045837402, "part_head": "14235678" },
       { "length": 672, "string": "BB[M]B[M]B[sM]Y[W]B[sW]B", "avg_score": 0.05505371, "part_head": "13425678" },
       { "length": 672, "string": "BB[sM]B[M]Y[sW]B[W]B[W]B", "avg_score": 0.059509277, "part_head": "13425678" },

--- a/monument/test/src/common.rs
+++ b/monument/test/src/common.rs
@@ -346,7 +346,7 @@ fn write_actual_results(cases: Vec<RunTestCase>) -> anyhow::Result<()> {
 fn write_results(results: &ResultsFile, path: &str) -> anyhow::Result<()> {
     let unformatted_json = serde_json::to_string(results)
         .with_context(|| format!("Error serialising results file {:?}", path))?;
-    let formatted_json = goldilocks_json_fmt::format_within_width(&unformatted_json, 115)
+    let formatted_json = goldilocks_json_fmt::format_within_width(&unformatted_json, 120)
         .expect("`serde_json` should emit valid JSON");
 
     let path_from_cargo_toml = PathBuf::from(PATH_TO_MONUMENT_DIR).join(path);

--- a/monument/test/src/test.rs
+++ b/monument/test/src/test.rs
@@ -31,7 +31,7 @@ fn main() -> anyhow::Result<()> {
         }
     } else {
         // If no args were given, just run the tests
-        match common::run(common::RunType::Test)? {
+        match common::run()? {
             common::Outcome::Fail => Err(anyhow::Error::msg("Tests failed")),
             common::Outcome::Pass => Ok(()),
         }


### PR DESCRIPTION
Allow `{queue,graph_size}_limit` to be set in the TOML files.  This makes more sense than CLI args, because a given search will likely always need the same limit adjustments.