### PR TITLE
Print leads for single-method positional comps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 ### Monument
+- (#124) Fix incorrect output for single-method cyclic comps.
 - (#122) Stop graph optimisation when all passes fail to make progress once (rather than waiting for
     an entire run of passes to not make progress).
 - (#121) Renamed `lead_location` to `label` (for brevity).

--- a/monument/lib/src/lib.rs
+++ b/monument/lib/src/lib.rs
@@ -482,7 +482,7 @@ impl Comp {
         s.push_str(if is_snap_start { "<" } else { "" });
         while let Some(path_elem) = path_iter.next() {
             // Method text
-            if query.is_spliced() {
+            if query.is_spliced() || query.call_display_style == CallDisplayStyle::Positional {
                 // Add one shorthand for every lead *covered* (not number of lead heads reached)
                 //
                 // TODO: Deal with half-lead spliced

--- a/monument/test/cases/regression/single-method-cyclic.toml
+++ b/monument/test/cases/regression/single-method-cyclic.toml
@@ -1,0 +1,3 @@
+length = 672
+method = "Plain Bob Major"
+part_head = "18234567"

--- a/monument/test/results.json
+++ b/monument/test/results.json
@@ -3139,6 +3139,16 @@
       { "length": 384, "string": "D[xB]Y[sH]DD[sH]", "avg_score": 0.015625, "part_head": "13425678" }
     ]
   },
+  "test/cases/regression/single-method-cyclic.toml": {
+    "comps": [
+      { "length": 672, "string": "#PPPP[s]P[s]P[-]", "avg_score": 0.1000061, "part_head": "17823456" },
+      { "length": 672, "string": "#PPPP[-]P[s]P[s]", "avg_score": 0.10296631, "part_head": "17823456" },
+      { "length": 672, "string": "#PPPP[s]P[-]P[s]", "avg_score": 0.10296631, "part_head": "17823456" },
+      { "length": 672, "string": "#PPPP[-]P[-]P[-]", "avg_score": 0.1104126, "part_head": "17823456" },
+      { "length": 672, "string": "#P[s]P[s]PPPP", "avg_score": 0.13064575, "part_head": "14567823" },
+      { "length": 672, "string": "#P[-]P[-]PPPP", "avg_score": 0.14108276, "part_head": "14567823" }
+    ]
+  },
   "test/cases/self-false-1.toml": {
     "comps": [
       { "length": 288, "string": "BB[M]BBB[B]BBB[W]B", "avg_score": 0.1166687 },


### PR DESCRIPTION
Makes the behaviour consistent with <0.10.0.