### PR TITLE
Add explicit memory limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ monument/test/.last-results.json
 
 # Where I store comps I'm working on that I don't want to show to everyone
 */comps/
+monument/bench/
 
 # All callgrind files
 **/callgrind*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,10 +678,12 @@ dependencies = [
  "hmap",
  "index_vec",
  "itertools",
+ "kneasle_ringing_utils",
  "log",
  "num_cpus",
  "ordered-float",
  "serde",
+ "sysinfo",
 ]
 
 [[package]]
@@ -708,6 +710,7 @@ dependencies = [
  "serde_json",
  "simple_logger",
  "structopt",
+ "sysinfo",
  "toml",
  "walkdir",
 ]
@@ -1293,6 +1296,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae2421f3e16b3afd4aa692d23b83d0ba42ee9b0081d5deeb7d21428d7195fb1"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "datasize"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdaf1625dae32ea757a4a98e6f59496bb4fe80a41efb0bd57e631f6cb341770"
+dependencies = [
+ "datasize_derive",
+]
+
+[[package]]
+name = "datasize_derive"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1065db16e6dad1cfa0f50966d8405bb9f6d13f74f34d685b417f301cb32f1d86"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +673,7 @@ version = "0.11.0"
 dependencies = [
  "bellframe",
  "bit-vec",
+ "datasize",
  "gcd",
  "hmap",
  "index_vec",

--- a/monument/cli/Cargo.toml
+++ b/monument/cli/Cargo.toml
@@ -24,6 +24,7 @@ ringing_utils = { version = "0.1.0", package = "kneasle_ringing_utils", path = "
 serde = { version = "1.0", features = ["derive"] }
 simple_logger = "2.3"
 structopt = "0.3"
+sysinfo = "0.26"
 toml = "0.5"
 
 [dev-dependencies]

--- a/monument/cli/guide.md
+++ b/monument/cli/guide.md
@@ -157,7 +157,7 @@ take you to more in-depth docs about it.
 - [`length`](#length-required)
 - [`num_comps = 100`](#num_comps)
 - [`allow_false = false`](#allow_false)
-- [`queue_limit`](#queue_limit)
+- ~~[`queue_limit`](#queue_limit)~~ _(removed in v0.12.0)_
 - [`graph_size_limit`](#graph_size_limit)
 
 **Methods:**
@@ -176,7 +176,7 @@ take you to more in-depth docs about it.
 - [`calls = []`](#calls-2)
 
 **Music:**
-- ~[`default_music = true`](#default_music)~ _(since v0.8.0, replaced by `base_music` in v0.9.0)_
+- ~~[`default_music = true`](#default_music)~~ _(since v0.8.0, replaced by `base_music` in v0.9.0)_
 - [`base_music = "default"`](#base_music) _(since v0.9.0)_
 - [`music_file`](#music_file) (optional)
 - [`music = []`](#music-2)
@@ -188,7 +188,7 @@ take you to more in-depth docs about it.
 - [`split_tenors = false`](#split_tenors)
 - [`ch_weights = []`](#ch_weights)
 - [`handbell_coursing_weight = 0`](#handbell_coursing_weight)
-- ~[`leadwise`](#leadwise) (default set by Monument)~ _(removed in v0.10.0)_
+- ~~[`leadwise`](#leadwise) (default set by Monument)~~ _(removed in v0.10.0)_
 
 **Starts/Ends:**
 - [`start_row = <rounds>`](#start_row-and-end_row) _(since v0.10.0)_

--- a/monument/cli/src/args.rs
+++ b/monument/cli/src/args.rs
@@ -25,8 +25,9 @@ pub struct CliArgs {
     pub quietness: usize,
 }
 
-/// Parameters passed directly into `monument_cli::run`, used to generated the [`monument::Config`]
-/// for the search.
+// Parameters passed directly into `monument_cli::run`, used to generated the [`monument::Config`]
+// for the search.  This isn't a doc-comment because doc comments overrides
+// `#[structopt(about = "...")]`.
 #[derive(Default, Debug, Clone, StructOpt)]
 pub struct Options {
     /// The maximum number of threads that Monument will use.

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -40,8 +40,6 @@ pub struct Spec {
     allow_false: bool,
 
     /* CONFIG OPTIONS */
-    /// If set, overrides `-Q`/`--queue-limit` CLI argument
-    queue_limit: Option<usize>,
     /// If set, overrides `--graph-size-limit` CLI argument
     graph_size_limit: Option<usize>,
 
@@ -264,8 +262,8 @@ impl Spec {
         if let Some(limit) = opts.graph_size_limit.or(self.graph_size_limit) {
             config.graph_size_limit = limit;
         }
-        if let Some(limit) = opts.queue_limit.or(self.queue_limit) {
-            config.queue_limit = limit;
+        if let Some(limit) = opts.mem_limit {
+            config.mem_limit = limit;
         }
         config
     }

--- a/monument/lib/Cargo.toml
+++ b/monument/lib/Cargo.toml
@@ -20,4 +20,6 @@ itertools = "0.10"
 log = "0.4"
 num_cpus = "1.13"
 ordered-float = "3.0"
+ringing_utils = { version = "0.1.0", package = "kneasle_ringing_utils", path = "../../utils/" }
 serde = { version = "1.0", features = ["derive"] }
+sysinfo = "0.26"

--- a/monument/lib/Cargo.toml
+++ b/monument/lib/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/kneasle/ringing-monorepo"
 [dependencies]
 bellframe = { version = "0.10.0", path = "../../bellframe/" }
 bit-vec = "0.6"
+datasize = "0.2"
 gcd = "2.0"
 hmap = "0.1"
 index_vec = "0.1"

--- a/monument/lib/src/graph/mod.rs
+++ b/monument/lib/src/graph/mod.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use bellframe::Row;
+use datasize::DataSize;
 
 use crate::{
     group::PhRotation,
@@ -105,7 +106,7 @@ impl Link {
 
 /// What a `Link` points to.  This is either a [`StartOrEnd`](Self::StartOrEnd), or a specific
 /// [`Chunk`](Self::Chunk).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, DataSize)]
 pub(crate) enum LinkSide<Id> {
     StartOrEnd,
     Chunk(Id),

--- a/monument/lib/src/group.rs
+++ b/monument/lib/src/group.rs
@@ -1,6 +1,7 @@
 use std::ops::{Deref, Mul, Not};
 
 use bellframe::{Row, RowBuf, Stage};
+use datasize::DataSize;
 use gcd::Gcd;
 
 /// A group of [`Row`]s, used to represent part heads.  Currently limited to cyclic groups (in the
@@ -18,7 +19,7 @@ pub struct PartHeadGroup {
 }
 
 /// A compact representation of a single `PartHead` within a [`PartHeadGroup`]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, DataSize)]
 pub struct PartHead {
     /// The index into the owning [`PartHeadGroup`]'s `part_heads` list.
     index: u8,

--- a/monument/lib/src/lib.rs
+++ b/monument/lib/src/lib.rs
@@ -36,14 +36,6 @@
 //!    currently has only one consumer (the CLI) and therefore its API has been heavily bent by the
 //!    needs of a CLI.  Before I'm happy to let others use this library, I need to try embedding it
 //!    so I can get a proper feel for what the library feels like to use.
-//! 2. Currently, Monument's search routine uses potentially unbounded amounts of memory.  This is
-//!    basically acceptable for a simple CLI tool, but is completely unacceptable when being
-//!    embedded into larger applications - you simply cannot have your program be nuked by
-//!    the OS because a library exhausted the system's memory.  It is currently possible to control
-//!    the usage using the [`Config::queue_limit`](search::Config::queue_limit) parameter, but this
-//!    is at best a proxy for memory usage.  Soon™, `queue_limit` will be replaced with a proper
-//!    memory limit: the search routine will set `queue_limit` internally to make sure the memory
-//!    usage is bounded.
 // TODO: Add example
 
 #![deny(clippy::all)]

--- a/monument/lib/src/search/graph.rs
+++ b/monument/lib/src/search/graph.rs
@@ -170,8 +170,8 @@ fn link_score(
 }
 
 index_vec::define_index_type! { pub struct ChunkIdx = usize; }
-index_vec::define_index_type! { pub struct StartIdx = usize; }
-index_vec::define_index_type! { pub struct SuccIdx = usize; }
+index_vec::define_index_type! { pub struct StartIdx = u32; }
+index_vec::define_index_type! { pub struct SuccIdx = u32; }
 type ChunkVec<T> = index_vec::IndexVec<ChunkIdx, T>;
 type StartVec<T> = index_vec::IndexVec<StartIdx, T>;
 type SuccVec<T> = index_vec::IndexVec<SuccIdx, T>;

--- a/monument/lib/src/search/mod.rs
+++ b/monument/lib/src/search/mod.rs
@@ -6,6 +6,7 @@ mod path;
 mod prefix;
 
 use std::{
+    convert::TryInto,
     ops::RangeInclusive,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -217,9 +218,8 @@ pub struct Config {
     pub graph_size_limit: usize,
 
     /* Search */
-    /// The maximum number of [`Composition`] prefixes stored simultaneously whilst searching.
-    /// Hopefully this will soon be deprecated in favour of an explicit memory limit.
-    pub queue_limit: usize,
+    /// The maximum number of bytes of heap memory which the search routine is allowed to use.
+    pub mem_limit: usize,
     /// If `true`, the data structures used by searches will be leaked using [`std::mem::forget`].
     /// This massively improves the termination speed (because the search creates tons of small
     /// allocations which we now don't need to explicitly free) but only makes sense for the CLI,
@@ -235,7 +235,9 @@ impl Default for Config {
 
             graph_size_limit: 100_000,
 
-            queue_limit: 10_000_000,
+            mem_limit: 10_000_000_000u64
+                .try_into()
+                .unwrap_or(usize::MAX - 500_000_000), // TODO: Better default
             leak_search_memory: false,
         }
     }

--- a/monument/lib/src/search/mod.rs
+++ b/monument/lib/src/search/mod.rs
@@ -15,6 +15,8 @@ use std::{
 };
 
 use bellframe::Stage;
+use ringing_utils::BigNumInt;
+use sysinfo::SystemExt;
 
 use crate::{
     builder::{MethodId, MusicTypeId},
@@ -219,6 +221,7 @@ pub struct Config {
 
     /* Search */
     /// The maximum number of bytes of heap memory which the search routine is allowed to use.
+    /// Defaults to 90% of available memory.
     pub mem_limit: usize,
     /// If `true`, the data structures used by searches will be leaked using [`std::mem::forget`].
     /// This massively improves the termination speed (because the search creates tons of small
@@ -230,14 +233,30 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
+        // Use as a memory limit either 90% of available memory or 5GB if we can't access
+        // availability
+        let ideal_mem_limit = if sysinfo::System::IS_SUPPORTED {
+            (sysinfo::System::new_all().available_memory() as f32 * 0.9) as u64
+        } else {
+            5_000_000_000u64
+        };
+        // However, always use 500MB less than the memory that's accessible by the system (i.e. if
+        // we're running in 32-bit environments like WASM, we can't fill available memory so we
+        // just default to `2*32 - 500MB ~= 3.5GB`)
+        let pointer_size_limit = (usize::MAX as u64).saturating_sub(500_000_000);
+        let mem_limit: usize = ideal_mem_limit
+            .min(pointer_size_limit)
+            .try_into()
+            .expect("Memory limit should fit into `usize`");
+
+        log::info!("Limiting memory usage to {}B", BigNumInt(mem_limit));
+
         Self {
             thread_limit: None,
 
             graph_size_limit: 100_000,
 
-            mem_limit: 10_000_000_000u64
-                .try_into()
-                .unwrap_or(usize::MAX - 500_000_000), // TODO: Better default
+            mem_limit,
             leak_search_memory: false,
         }
     }

--- a/monument/lib/src/search/mod.rs
+++ b/monument/lib/src/search/mod.rs
@@ -2,6 +2,7 @@
 
 mod best_first;
 mod graph;
+mod path;
 mod prefix;
 
 use std::{

--- a/monument/lib/src/search/path.rs
+++ b/monument/lib/src/search/path.rs
@@ -1,3 +1,5 @@
+use datasize::DataSize;
+
 use super::graph::{StartIdx, SuccIdx};
 
 /// A container of prefix paths, stored as a linked-list style tree such that common prefixes are
@@ -187,6 +189,16 @@ impl Paths {
     }
 }
 
+impl DataSize for Paths {
+    const IS_DYNAMIC: bool = true;
+
+    const STATIC_HEAP_SIZE: usize = 0;
+
+    fn estimate_heap_size(&self) -> usize {
+        std::mem::size_of::<Self>() + self.nodes.len() * std::mem::size_of::<u64>()
+    }
+}
+
 #[track_caller]
 fn as_high_31_bits(v: u32) -> u64 {
     assert_eq!(
@@ -199,5 +211,8 @@ fn as_high_31_bits(v: u32) -> u64 {
 
 const EMPTY_BIT_MASK: u64 = 1 << 63; // Bits `63..64`
 
-index_vec::define_index_type! { pub struct PathId = u32; }
+index_vec::define_index_type! {
+    #[derive(DataSize)]
+    pub struct PathId = u32;
+}
 const NULL_NODE_IDX: PathId = PathId::from_raw_unchecked(u32::MAX);

--- a/monument/lib/src/search/path.rs
+++ b/monument/lib/src/search/path.rs
@@ -1,0 +1,203 @@
+use super::graph::{StartIdx, SuccIdx};
+
+/// A container of prefix paths, stored as a linked-list style tree such that common prefixes are
+/// only stored once.
+#[derive(Debug)]
+pub(super) struct Paths {
+    /// Flat vector of [`PathNode`]s, stored compactly as 64-bit numbers.  The bits are used as
+    /// follows:
+    ///
+    /// |   Bits   | [`PathNode::Start`] |  [`PathNode::Cons`]  | [`PathNode::Empty`] |
+    /// |----------|---------------------|----------------------|---------------------|
+    /// | ` 0..32` |        zeros        | `last` ([`PathId`])  | `next` ([`PathId`]) |
+    /// | `32..63` |     [`StartIdx`]    | `succ` ([`SuccIdx`]) |        zeros        |
+    /// | `63..64` |        zero         |         zero         |         one         |
+    nodes: index_vec::IndexVec<PathId, u64>,
+    /// The first `num_starts` elements of `nodes` are all [`PathNode::Start`]s
+    num_starts: usize,
+    /// The index of an [`PathNode::Empty`] node.  The empty nodes form a linked list, of which
+    /// this is the head.
+    first_empty: PathId,
+
+    /// Number of non-[`PathNode::Empty`] nodes
+    size: usize,
+}
+
+#[derive(Debug)]
+enum PathNode {
+    /// This node has no predecessors and is the start of a path
+    Start(StartIdx),
+    /// This node extends the `PathNode` at the `usize` index by taking the [`SuccIdx`]th successor
+    /// of the currently reached node.
+    Cons { last: PathId, succ: SuccIdx },
+    /// This slot is empty and the next empty slot is at `next`
+    Empty { next: PathId },
+}
+
+impl Paths {
+    /// Crates an empty set of [`Paths`].
+    pub(super) fn new() -> Self {
+        Self {
+            nodes: index_vec::IndexVec::new(),
+            num_starts: 0,
+            first_empty: NULL_NODE_IDX, // No empty nodes in the linked list
+            size: 0,
+        }
+    }
+
+    /// Add a new [`PathNode::Start`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if any non-start nodes have been `add`ed
+    pub(super) fn add_start(&mut self, start_idx: StartIdx) -> PathId {
+        assert_eq!(
+            self.nodes.len(),
+            self.num_starts,
+            "`add_start` called after other nodes were `add`ed."
+        );
+        self.size += 1;
+        self.num_starts += 1;
+        self.nodes.push(as_high_31_bits(start_idx.raw()))
+    }
+
+    /// Adds a new [`PathNode::Cons`] to this set of paths, returning its [`PathId`].
+    pub(super) fn add(&mut self, last: PathId, succ: SuccIdx) -> PathId {
+        // Generate the node data
+        let mut node_data = last.raw() as u64; // Put `last` into the low 32 bits
+        node_data |= as_high_31_bits(succ.raw()); // Put `succ` into the high 31 bits.  Note that
+                                                  // this also leaves the 'empty' bit still as `0`
+
+        self.size += 1; // It doesn't matter how the new node is added, the size always increases
+
+        if self.first_empty == NULL_NODE_IDX {
+            // No more empty nodes, so push to the vector
+            self.nodes.push(node_data)
+        } else {
+            // Get the index of the first empty node, and remove it from the head of the empty list
+            let empty_idx = self.first_empty;
+            let next_empty = match self.get(empty_idx) {
+                PathNode::Empty { next } => next,
+                _ => panic!("`next_empty` pointed to a non-empty node"),
+            };
+            self.first_empty = next_empty;
+            // Replace the empty node with the new node
+            self.nodes[empty_idx] = node_data;
+            empty_idx
+        }
+    }
+
+    /// Run a garbage collection pass to mark any unreachable nodes as 'empty'
+    pub(super) fn gc(&mut self, heads: impl IntoIterator<Item = PathId>) {
+        // Mark which nodes are reachable, by marking all the non-start nodes as 'empty' then
+        // marking any node reachable from `heads` as non-empty.  Start nodes cannot be GCed.
+        for node_data in self.nodes.iter_mut().skip(self.num_starts) {
+            *node_data |= EMPTY_BIT_MASK;
+        }
+        for head in heads {
+            self.mark_path_as_non_empty(head);
+        }
+        // Rebuild the empty node list and count the number of non-empty nodes
+        self.size = self.nodes.len();
+        self.first_empty = NULL_NODE_IDX;
+        for (idx, node_data) in self.nodes.iter_mut_enumerated().skip(self.num_starts) {
+            let is_empty = *node_data & EMPTY_BIT_MASK != 0;
+            if is_empty {
+                // Push this node to the `empty` list
+                *node_data = EMPTY_BIT_MASK | (self.first_empty.raw() as u64);
+                self.first_empty = idx;
+                self.size -= 1;
+            }
+        }
+    }
+
+    /// Mark this [`PathId`] and everything it reaches as 'non-empty'
+    fn mark_path_as_non_empty(&mut self, head: PathId) {
+        // Skip this if we've already marked this node (and its descendants) as reachable
+        if self.nodes[head] & EMPTY_BIT_MASK == 0 {
+            return;
+        }
+        // Set this node's 'empty' bit to `0` (it would have been set to `1` at the start of the GC
+        // pass)
+        self.nodes[head] &= !EMPTY_BIT_MASK;
+        match self.get(head) {
+            PathNode::Start(_) => {} // We've finished this linked list
+            PathNode::Cons { last, succ: _ } => self.mark_path_as_non_empty(last),
+            PathNode::Empty { .. } => unreachable!("We just set the 'empty' bit to 0"),
+        }
+    }
+
+    /// Return the path which finishes at a given [`PathId`].
+    pub(super) fn flatten(&self, node_idx: PathId) -> (StartIdx, Vec<SuccIdx>) {
+        let mut succs = Vec::new();
+        let start_idx = self.flatten_recursive(node_idx, &mut succs);
+        (start_idx, succs)
+    }
+
+    fn flatten_recursive(&self, node_idx: PathId, succs: &mut Vec<SuccIdx>) -> StartIdx {
+        match self.get(node_idx) {
+            PathNode::Start(start_idx) => start_idx,
+            PathNode::Cons { last, succ } => {
+                let start_idx = self.flatten_recursive(last, succs);
+                succs.push(succ);
+                start_idx
+            }
+            PathNode::Empty { .. } => panic!("GCed nodes shouldn't be in a path"),
+        }
+    }
+
+    /// Gets the [`PathNode`] at a given [`PathId`].
+    fn get(&self, idx: PathId) -> PathNode {
+        let data = self.nodes[idx];
+        // Deconstruct the 64-bit value
+        let is_empty = (data & EMPTY_BIT_MASK) != 0; // Node is `Empty` iff `EMPTY_BIT` is 1
+        let is_start = idx.index() < self.num_starts; // Node is `Start` if it's within `num_starts`
+        let low_32_bits = PathId::from_raw(data as u32); // Read bits `0..32`
+        let high_31_bits = (data >> 32) as u32 & 0x7FFF_FFFF; // Read bits `32..63`
+
+        // Construct node
+        if is_start {
+            assert!(!is_empty); // Start nodes shouldn't be GCed
+            PathNode::Start(StartIdx::from_raw(high_31_bits))
+        } else if is_empty {
+            PathNode::Empty { next: low_32_bits }
+        } else {
+            PathNode::Cons {
+                last: low_32_bits,
+                succ: SuccIdx::from_raw(high_31_bits),
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn debug_nodes(&self) {
+        for (idx, data) in self.nodes.iter_enumerated() {
+            let empty_bit = data >> 63;
+            let high_31_bits = (data >> 32) & 0x7FFF_FFFF;
+            let low_32_bits = *data as u32;
+            println!(
+                "{:>4?}: {} {:031b} {:032b} -> {:?}",
+                idx.raw(),
+                empty_bit,
+                high_31_bits,
+                low_32_bits,
+                self.get(idx)
+            );
+        }
+    }
+}
+
+#[track_caller]
+fn as_high_31_bits(v: u32) -> u64 {
+    assert_eq!(
+        v & (1 << 31),
+        0,
+        "High 31-bit values should be smaller than 2^31"
+    );
+    (v as u64) << 32
+}
+
+const EMPTY_BIT_MASK: u64 = 1 << 63; // Bits `63..64`
+
+index_vec::define_index_type! { pub struct PathId = u32; }
+const NULL_NODE_IDX: PathId = PathId::from_raw_unchecked(u32::MAX);

--- a/monument/lib/src/search/prefix.rs
+++ b/monument/lib/src/search/prefix.rs
@@ -6,6 +6,7 @@ use std::{
 
 use bellframe::Row;
 use bit_vec::BitVec;
+use datasize::DataSize;
 use itertools::Itertools;
 
 use crate::{
@@ -13,7 +14,7 @@ use crate::{
     composition::{Composition, PathElem},
     graph::LinkSide,
     group::PartHead,
-    utils::{Counts, Score, TotalLength},
+    utils::{div_rounding_up, Counts, Score, TotalLength},
 };
 
 use super::{
@@ -107,6 +108,14 @@ impl CompPrefix {
             length,
             avg_score: score / length.as_usize() as f32,
         }
+    }
+
+    /// Returns the number of bytes of memory occupied by `self`
+    pub fn size(&self) -> usize {
+        std::mem::size_of::<Self>()
+            + std::mem::size_of::<PrefixInner>()
+            + div_rounding_up(self.inner.unringable_chunks.len(), 8)
+            + self.inner.method_counts.estimate_heap_size()
     }
 
     pub fn path_head(&self) -> PathId {

--- a/monument/lib/src/utils/counts.rs
+++ b/monument/lib/src/utils/counts.rs
@@ -1,12 +1,13 @@
 use std::ops::{Add, AddAssign, Index, IndexMut, Mul, RangeInclusive};
 
+use datasize::DataSize;
 use itertools::Itertools;
 
 use super::TotalLength;
 
 /// A collection of counts of something, usually instances of music types or rows of a given
 /// method.  Addition/subtraction is performed element-wise.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, DataSize)]
 pub(crate) struct Counts(Vec<usize>);
 
 impl Counts {

--- a/monument/lib/src/utils/lengths.rs
+++ b/monument/lib/src/utils/lengths.rs
@@ -3,6 +3,8 @@ use std::{
     ops::{Add, AddAssign, Sub, SubAssign},
 };
 
+use datasize::DataSize;
+
 /// A length **in one part** of the composition.  This and [`TotalLength`] allow the compiler to
 /// disallow mixing up the different definitions of 'length'.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -11,7 +13,7 @@ pub(crate) struct PerPartLength(u32);
 
 /// The combined length **across all parts**.  This and [`PerPartLength`] allow the compiler to
 /// disallow mixing up the different definitions of 'length'.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, DataSize)]
 pub(crate) struct TotalLength(u32);
 
 impl PerPartLength {


### PR DESCRIPTION
Replaces `--queue-limit` (at best a proxy for memory usage) with an explicit `--mem-limit` which says how many bytes Monument is allowed to allocate in its search routine.  This is not a hard memory limit, because Monument allocates other memory (which won't be counted) but this is fine as it stops Monument running the system out of memory and having its process nuked by the OS (an absolute no-go if Monument is a library inside a larger application).

Fixes #20 (at last!).