### PR TITLE
Remove `serde` dependency from `lib/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## (Unreleased)
+
+### Monument
+- (#167) Remove dependence on `serde` from Monument's library.  Now, all the handling of TOML files
+    is in `monument_cli`.
+
+### Bellframe
+
+---
+
+
+
 ## 21st October 2022
 
 ### Monument v0.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,6 @@ dependencies = [
  "log",
  "num_cpus",
  "ordered-float",
- "serde",
  "sysinfo",
 ]
 

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -5,8 +5,7 @@ use colored::Colorize;
 use itertools::Itertools;
 use monument::{
     builder::{
-        self, CallDisplayStyle, EndIndices, Method, SpliceStyle, DEFAULT_BOB_WEIGHT,
-        DEFAULT_SINGLE_WEIGHT,
+        self, CallDisplayStyle, EndIndices, Method, DEFAULT_BOB_WEIGHT, DEFAULT_SINGLE_WEIGHT,
     },
     Config, Search, SearchBuilder,
 };
@@ -220,7 +219,7 @@ impl Spec {
             Some(idxs) => EndIndices::Specific(idxs.to_vec()),
             None => EndIndices::Any,
         };
-        search_builder.splice_style = self.splice_style;
+        search_builder.splice_style = self.splice_style.into();
         search_builder.splice_weight = self.splice_weight;
         // Calls
         search_builder.base_calls = self.base_calls()?;
@@ -456,6 +455,33 @@ pub struct MethodCommon {
     course_heads: Option<Vec<String>>,
     start_indices: Option<Vec<isize>>,
     end_indices: Option<Vec<isize>>,
+}
+
+/// The different styles of spliced that can be generated.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize)]
+pub enum SpliceStyle {
+    /// Splices could happen at any lead label (usually just
+    /// [lead ends](bellframe::method::LABEL_LEAD_END)).
+    #[serde(rename = "leads")]
+    LeadLabels,
+    /// Splices only happen at calls.
+    #[serde(rename = "calls")]
+    Calls,
+}
+
+impl From<self::SpliceStyle> for monument::builder::SpliceStyle {
+    fn from(style: self::SpliceStyle) -> Self {
+        match style {
+            self::SpliceStyle::LeadLabels => monument::builder::SpliceStyle::LeadLabels,
+            self::SpliceStyle::Calls => monument::builder::SpliceStyle::Calls,
+        }
+    }
+}
+
+impl Default for SpliceStyle {
+    fn default() -> Self {
+        Self::LeadLabels
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/monument/lib/Cargo.toml
+++ b/monument/lib/Cargo.toml
@@ -21,5 +21,4 @@ log = "0.4"
 num_cpus = "1.13"
 ordered-float = "3.3"
 ringing_utils = { version = "0.1.0", package = "kneasle_ringing_utils", path = "../../utils/" }
-serde = { version = "1.0", features = ["derive"] }
 sysinfo = "0.26"

--- a/monument/lib/src/builder/methods.rs
+++ b/monument/lib/src/builder/methods.rs
@@ -9,7 +9,6 @@ use bellframe::{
     method::LABEL_LEAD_END, method_lib::QueryError, Bell, Mask, MethodLib, Row, Stage,
 };
 use itertools::Itertools;
-use serde::Deserialize;
 
 use crate::query::{self, CallVec, MethodIdx, MethodVec};
 
@@ -134,14 +133,12 @@ impl Method {
 }
 
 /// The different styles of spliced that can be generated.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum SpliceStyle {
     /// Splices could happen at any lead label (usually just
     /// [lead ends](bellframe::method::LABEL_LEAD_END)).
-    #[serde(rename = "leads")]
     LeadLabels,
     /// Splices only happen at calls.
-    #[serde(rename = "calls")]
     Calls,
 }
 


### PR DESCRIPTION
Removes the last piece of TOML parsing that was in `lib/`, thus finishing the split between 'general' library code and CLI-specific parsing code.