### PR TITLE
Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,23 @@
 ### Monument v0.14.0
 
 #### Headline Features
+
+#### Smaller Changes
 - (#205) Remove chunks and links which contribute too much method counts.  This should have a small
     speed improvement for compositions which include one lead of each method in each part
     (e.g. 23-spliced Surprise Major).
+- (#221) In the guide, use valid values for `{start,end}_rows`.
 
 #### Internal Improvements
 - (#203) Automate the release workflow.  Now, `cargo cut-release` is enough to trigger the
     whole release pipeline.
 - (#204) Implement benchmark runner.
+
+### Bellframe v0.12.0
+- (#221) Add `Bell::MAX`, which returns the largest `Bell` possible (i.e. the 254th)
+- (#221) Stop bell-path methods (e.g. `Block::path_of`) from returning `Option`.  Instead, passing
+    a `Bell` out of the `Block`'s `Stage` will cause a panic.
+- (#221) Add `Mask::contains`, returning `true` if the `Mask` constrains that `Bell`.
 
 ---
 

--- a/bellframe/src/bell.rs
+++ b/bellframe/src/bell.rs
@@ -147,6 +147,9 @@ impl Bell {
     /// ```
     pub const TREBLE: Bell = Bell { index: 0 };
 
+    /// The largest [`Bell`] that can be stored.
+    pub const MAX: Bell = Bell { index: 254 };
+
     /// Converts this `Bell` into the [`char`] that it should be displayed as.  If the `Bell` is
     /// too big to have a corresponding name, then [`None`] is returned.
     ///

--- a/bellframe/src/block.rs
+++ b/bellframe/src/block.rs
@@ -264,15 +264,15 @@ impl<A> Block<A> {
 
     /// Returns the places of a given [`Bell`] in each [`Row`] of this `Block`.  Also returns
     /// the place of `bell` in the leftover row.
-    pub fn path_of(&self, bell: Bell) -> Option<(Vec<usize>, usize)> {
-        let mut full_path = self.full_path_of(bell)?;
+    pub fn path_of(&self, bell: Bell) -> (Vec<usize>, usize) {
+        let mut full_path = self.full_path_of(bell);
         let place_in_leftover_row = full_path.pop().unwrap();
-        Some((full_path, place_in_leftover_row))
+        (full_path, place_in_leftover_row)
     }
 
     /// Returns the places of a given [`Bell`] in each [`Row`] of this `Block`, **including**
     /// the leftover row.
-    pub fn full_path_of(&self, bell: Bell) -> Option<Vec<usize>> {
+    pub fn full_path_of(&self, bell: Bell) -> Vec<usize> {
         self.rows.path_of(bell) // Delegate to `SameStageVec`
     }
 

--- a/bellframe/src/mask.rs
+++ b/bellframe/src/mask.rs
@@ -120,6 +120,10 @@ impl Mask {
         Self { bells }
     }
 
+    pub fn contains(&self, bell: Bell) -> bool {
+        self.bells.contains(&Some(bell))
+    }
+
     /// Returns an [`Iterator`] over the [`Bell`]s (or gaps) in `self`.
     pub fn bells(&self) -> impl DoubleEndedIterator<Item = Option<Bell>> + Clone + '_ {
         self.bells.iter().copied()

--- a/bellframe/src/method/class.rs
+++ b/bellframe/src/method/class.rs
@@ -522,7 +522,7 @@ impl Cycle {
                 // Mark that we've covered this bell
                 bells_left[place_bell.index()] = false;
                 // Track this bell's path through the next lead
-                let (path, next_place_bell) = first_lead.path_of(place_bell).unwrap();
+                let (path, next_place_bell) = first_lead.path_of(place_bell);
                 // Add path & place_bell to this cycle
                 place_bells_in_cycle.push(place_bell);
                 full_path.extend(path);

--- a/bellframe/src/row/same_stage_vec.rs
+++ b/bellframe/src/row/same_stage_vec.rs
@@ -218,11 +218,8 @@ impl SameStageVec {
 
     /// Returns a [`Vec`] containing the place of a [`Bell`] in each [`Row`] in this
     /// `SameStageVec`.  Returns `None` if the [`Bell`] exceeds the [`Stage`] of `self`.
-    pub fn path_of(&self, bell: Bell) -> Option<Vec<usize>> {
-        (bell.index() < self.stage().num_bells()).then(
-            // TODO: Write a vectorised routine for this
-            || self.iter().map(|r| r.place_of(bell).unwrap()).collect_vec(),
-        )
+    pub fn path_of(&self, bell: Bell) -> Vec<usize> {
+        self.iter().map(|r| r.place_of(bell).unwrap()).collect_vec()
     }
 
     ////////////////

--- a/monument/bench/b8-ala-MBD.toml
+++ b/monument/bench/b8-ala-MBD.toml
@@ -1,0 +1,16 @@
+length = "peal"
+method = "Bristol Surprise Major"
+
+bob_weight = -15
+bobs_only = true
+
+music = [
+    # { patterns = ["*6578"], weight = 1, show = false },
+    { patterns = ["*5678", "*8765"], weight = 1, show = false },
+    { patterns = ["5678*", "8765*"], weight = 4, show = false },
+    { preset = "5678 combinations", weight = 0.1 }
+]
+
+[[ch_weights]]
+patterns = ["*78"]
+weight = 0.02

--- a/monument/bench/lincoln-spliced.toml
+++ b/monument/bench/lincoln-spliced.toml
@@ -1,0 +1,17 @@
+length = "peal"
+methods = [
+    "Lancashire Surprise Major",
+    "Ytterbium Surprise Major",
+    "Mareham Delight Major",
+    { title = "Deva Surprise Major", shorthand = "V" },
+    { title = "Double Coslany Court Bob Major", shorthand = "C", count = { min = 500, max = 700 } },
+    { title = "Double Norwich Court Bob Major", shorthand = "N", count = { min = 500, max = 700 } },
+]
+method_count = 960
+
+part_head = "134265"
+course_heads = ["*78", "*7856", "*7865"]
+
+[[music]]
+preset = "5678 combinations"
+weight = 0.2

--- a/monument/bench/non-duffer/bristol-s8.toml
+++ b/monument/bench/non-duffer/bristol-s8.toml
@@ -1,0 +1,12 @@
+length = "peal"
+method = "Bristol Surprise Major"
+
+bob_weight = 0
+bobs_only = true
+
+non_duffer_courses = [
+    { masks = ["*5678", "*5x678", "*8765", "*8x765"], both_strokes = true, any_bells = true },
+    { masks = ["*6578", "*6x578", "*8x756"], both_strokes = true },
+]
+max_contiguous_duffer = 96
+max_total_duffer = 256

--- a/monument/cli/guide.md
+++ b/monument/cli/guide.md
@@ -195,8 +195,8 @@ take you to more in-depth docs about it.
 - [`max_contiguous_duffer`](#max_total_duffer-and-max_contiguous_duffer) _(added in v0.12.0)_
 
 **Starts/Ends:**
-- [`start_row = <rounds>`](#start_row-and-end_row) _(since v0.10.0)_
-- [`end_row = <rounds>`](#start_row-and-end_row) _(since v0.10.0)_
+- [`start_row = ""`](#start_row-and-end_row) _(since v0.10.0.  "" is equivalent to rounds)_
+- [`end_row = ""`](#start_row-and-end_row) _(since v0.10.0.  "" is equivalent to rounds)_
 - [`snap_start = false`](#snap_start)
 - [`start_indices`](#start_indices-and-end_indices) (default set by `snap_start`)
 - [`end_indices`](#start_indices-and-end_indices) (default to allow any finish)


### PR DESCRIPTION
- In the guide, use valid values for `{start,end}_rows`.
- Add `Bell::MAX`, which returns the largest `Bell` possible (i.e. the 254th)
- Stop bell-path methods (e.g. `Block::path_of`) from returning `Option`.  Instead, passing a `Bell` out of the `Block`'s `Stage` will cause a panic.
- Add `Mask::contains`, returning `true` if the `Mask` constrains that `Bell`.