### PR TITLE
Remove cached data from `Query`

### DIFF
--- a/bellframe/src/method/mod.rs
+++ b/bellframe/src/method/mod.rs
@@ -120,6 +120,11 @@ impl Method {
         self.first_lead.len()
     }
 
+    /// How many [`Row`]s are in one course of this `Method`?
+    pub fn course_len(&self) -> usize {
+        self.lead_len() * self.lead_head().order()
+    }
+
     /// Gets the [`Stage`] of this `Method`
     #[inline]
     pub fn stage(&self) -> Stage {

--- a/monument/lib/src/atw.rs
+++ b/monument/lib/src/atw.rs
@@ -60,7 +60,7 @@ impl AtwTable {
         let working_bells = query
             .stage
             .bells()
-            .filter(|b| !query.fixed_bells.iter().any(|(b1, _)| b1 == b)) // not in fixed_bells
+            .filter(|b| !query.fixed_bells().iter().any(|(b1, _)| b1 == b)) // not in fixed_bells
             .collect_vec();
         // Which bells do we have to track, according to the part-head.  For example, for a
         // composition with part head `13425678`, 3 and 4 will not have their place bells

--- a/monument/lib/src/atw.rs
+++ b/monument/lib/src/atw.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 
 use crate::{
     graph::ChunkId,
-    parameters::{MethodIdx, MethodVec, Parameters},
+    parameters::{Method, MethodIdx, MethodVec, Parameters},
     query::Query,
     utils::{div_rounding_up, lengths::PerPartLength},
 };
@@ -297,7 +297,7 @@ fn make_bell_place_to_bitmap_index(
 // accounted for
 fn total_unique_row_positions(
     working_bells: &[Bell],
-    methods: &MethodVec<crate::query::Method>,
+    methods: &MethodVec<Method>,
     flags: &[AtwFlag],
 ) -> usize {
     let total_unique_row_positions = working_bells.len() // Working bells
@@ -347,7 +347,7 @@ fn place_bell_range_boundaries(
 fn range_boundaries_to_flags(
     working_bells: &[Bell],
     part_head_cycles: &[Vec<Bell>],
-    methods: &MethodVec<crate::query::Method>,
+    methods: &MethodVec<Method>,
     params: &Parameters,
     range_boundaries: HashMap<(Bell, u8, MethodIdx), Vec<usize>>,
 ) -> Vec<AtwFlag> {
@@ -391,12 +391,12 @@ fn range_boundaries_to_flags(
     flags
 }
 
-/// Given a [`crate::query::Method`], determine which sets of `(bell, place bell)` pairs can be
+/// Given a [`Method`], determine which sets of `(bell, place bell)` pairs can be
 /// combined and tracked with one flag.
 fn bell_place_sets(
     working_bells: &[Bell],
     part_head_cycles: &[Vec<Bell>],
-    method: &crate::query::Method,
+    method: &Method,
     params: &Parameters,
 ) -> Vec<Vec<(Bell, u8)>> {
     let mut bells_left_to_track = working_bells.iter().copied().collect::<HashSet<_>>();

--- a/monument/lib/src/graph/build/falseness.rs
+++ b/monument/lib/src/graph/build/falseness.rs
@@ -91,7 +91,7 @@ impl FalsenessTable {
         // generating false links.
         let mut masks_used = HashSet::<(ChunkRange, Mask)>::new();
         for (method_idx, method_data) in query.methods.iter_enumerated() {
-            for lead_head_mask in &method_data.allowed_lead_masks {
+            for lead_head_mask in method_data.allowed_lead_masks(&query.parameters) {
                 for (id, len) in chunks {
                     if id.method == method_idx && lead_head_mask.matches(&id.lead_head) {
                         masks_used

--- a/monument/lib/src/graph/build/falseness.rs
+++ b/monument/lib/src/graph/build/falseness.rs
@@ -10,7 +10,7 @@ use std::{
     time::Instant,
 };
 
-use bellframe::{Mask, Row, RowBuf, Truth};
+use bellframe::{Mask, Row, RowBuf, SameStageVec, Truth};
 use itertools::Itertools;
 
 use super::{ChunkEquivalenceMap, ChunkIdInFirstPart};
@@ -216,7 +216,7 @@ fn generate_falseness_entries(
 // HELPER FUNCTIONS FOR TABLE BUILD //
 //////////////////////////////////////
 
-type RowGroups<'m_datas> = HashMap<Mask, Vec<&'m_datas Row>>;
+type RowGroups = HashMap<Mask, SameStageVec>;
 type FalseTranspositions<'masks, 'groups> =
     HashMap<&'masks (ChunkRange, Mask), HashMap<&'groups (ChunkRange, Mask), HashSet<RowBuf>>>;
 
@@ -321,14 +321,11 @@ fn reduce_masks(
 fn group_rows(
     masks_used_in_all_parts: HashSet<(ChunkRange, Mask)>,
     query: &Query,
-) -> (
-    HashSet<ChunkRange>,
-    HashMap<(ChunkRange, Mask), HashMap<Mask, Vec<&Row>>>,
-) {
+) -> (HashSet<ChunkRange>, HashMap<(ChunkRange, Mask), RowGroups>) {
     let mut self_false_ranges = HashSet::<ChunkRange>::new();
     let mut row_groups = HashMap::<(ChunkRange, Mask), RowGroups>::new();
     'range_mask_loop: for (range, mask) in &masks_used_in_all_parts {
-        let plain_course = &query.methods[range.start.method].plain_course;
+        let plain_course = query.methods[range.start.method].plain_course();
 
         // The chunks with the same `range` are either all self-false or all self-true
         if self_false_ranges.contains(range) {
@@ -352,8 +349,9 @@ fn group_rows(
             let transposed_mask = mask * row;
             row_groups_for_this_range
                 .entry(transposed_mask)
-                .or_default()
-                .push(row);
+                .or_insert_with(|| SameStageVec::new(query.stage))
+                .push(row)
+                .unwrap();
         }
 
         row_groups.insert((*range, mask.clone()), row_groups_for_this_range);
@@ -375,7 +373,7 @@ fn group_rows(
 /// `cartesian_product`s).
 fn generate_false_chunk_transpositions<'masks, 'groups>(
     masks_used: &'masks HashSet<(ChunkRange, Mask)>,
-    row_groups: &'groups HashMap<(ChunkRange, Mask), HashMap<Mask, Vec<&Row>>>,
+    row_groups: &'groups HashMap<(ChunkRange, Mask), RowGroups>,
 ) -> FalseTranspositions<'masks, 'groups> {
     let mut false_chunk_transpositions: FalseTranspositions = HashMap::new();
     // For every pair of `(range, mask)`s ...

--- a/monument/lib/src/graph/build/falseness.rs
+++ b/monument/lib/src/graph/build/falseness.rs
@@ -240,7 +240,7 @@ fn reduce_masks(
     query: &Query,
 ) {
     let mut fixed_bell_mask = Mask::any(query.stage);
-    for &(bell, place) in &query.fixed_bells {
+    for (bell, place) in query.fixed_bells() {
         fixed_bell_mask
             .set_bell(bell, place)
             .expect("Fixed bells shouldn't repeat");

--- a/monument/lib/src/graph/build/layout.rs
+++ b/monument/lib/src/graph/build/layout.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use crate::{
     graph::{ChunkId, Link, LinkSet, LinkSide, RowIdx},
     group::PhRotation,
-    parameters::{CallIdx, MethodId, MethodIdx, MethodVec, SpliceStyle},
+    parameters::{CallIdx, Method, MethodId, MethodIdx, MethodVec, SpliceStyle},
     query::Query,
     utils::{
         lengths::{PerPartLength, TotalLength},
@@ -492,7 +492,7 @@ fn create_links(
     call: Option<CallIdx>,
     row_after_link: &Row,
     label_to: &str,
-    method_from: &crate::query::Method,
+    method_from: &Method,
 
     allowed_lead_masks: &HashMap<MethodId, Vec<Mask>>,
     link_ends_by_label: &HashMap<&str, Vec<(RowIdx, RowBuf)>>,

--- a/monument/lib/src/graph/build/mod.rs
+++ b/monument/lib/src/graph/build/mod.rs
@@ -329,13 +329,13 @@ fn check_query(query: &Query) -> crate::Result<()> {
     //
     // For every CH mask ...
     for method in &query.methods {
-        for mask_in_first_part in &method.specified_course_head_masks {
+        for mask_in_first_part in &method.specified_course_masks(&query.parameters) {
             // ... for every part ...
             for part_head in query.part_head_group.rows() {
                 // ... check that the CH mask in that part is covered by some lead mask
                 let mask_in_other_part = part_head * mask_in_first_part;
                 let is_covered = method
-                    .allowed_lead_masks
+                    .allowed_lead_masks(&query.parameters)
                     .iter()
                     .any(|mask| mask_in_other_part.is_subset_of(mask));
                 if !is_covered {

--- a/monument/lib/src/parameters.rs
+++ b/monument/lib/src/parameters.rs
@@ -37,7 +37,7 @@ pub struct Parameters {
     // METHODS & CALLING
     pub maybe_unused_methods: Vec<Method>,
     pub splice_style: SpliceStyle,
-    pub splice_weight: f32, // TODO: Do we need so many instances of 'Score'
+    pub splice_weight: f32,
     pub maybe_unused_calls: Vec<Call>,
     pub call_display_style: CallDisplayStyle, // TODO: Make this defined per-method?
     pub atw_weight: Option<f32>,
@@ -202,6 +202,18 @@ pub struct Method {
 }
 
 impl Method {
+    pub fn shorthand(&self) -> String {
+        if self.custom_shorthand.is_empty() {
+            default_shorthand(&self.title())
+        } else {
+            self.custom_shorthand.clone()
+        }
+    }
+
+    pub fn add_sub_lead_idx(&self, sub_lead_idx: usize, len: PerPartLength) -> usize {
+        (sub_lead_idx + len.as_usize()) % self.lead_len()
+    }
+
     /////////////////////////
     // START/END LOCATIONS //
     /////////////////////////
@@ -282,6 +294,14 @@ impl Method {
     }
 }
 
+impl std::ops::Deref for Method {
+    type Target = bellframe::Method;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MethodId(pub u16);
 
@@ -310,28 +330,6 @@ pub enum SpliceStyle {
 impl Default for SpliceStyle {
     fn default() -> Self {
         Self::LeadLabels
-    }
-}
-
-impl Method {
-    pub fn shorthand(&self) -> String {
-        if self.custom_shorthand.is_empty() {
-            default_shorthand(&self.title())
-        } else {
-            self.custom_shorthand.clone()
-        }
-    }
-
-    pub fn add_sub_lead_idx(&self, sub_lead_idx: usize, len: PerPartLength) -> usize {
-        (sub_lead_idx + len.as_usize()) % self.lead_len()
-    }
-}
-
-impl std::ops::Deref for Method {
-    type Target = bellframe::Method;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
     }
 }
 

--- a/monument/lib/src/parameters.rs
+++ b/monument/lib/src/parameters.rs
@@ -220,7 +220,7 @@ impl Method {
             let lead_head =
                 Row::solve_xa_equals_b(self.row_in_plain_lead(sub_lead_idx), row).unwrap();
             // This start is valid if it matches at least one of this method's lead head masks
-            if self.is_lead_head_allowed(&lead_head, &params.fixed_bells()) {
+            if self.is_lead_head_allowed(&lead_head, params) {
                 locations.push((lead_head, sub_lead_idx));
             }
         }
@@ -267,14 +267,18 @@ impl Method {
     // ALLOWED LEADS //
     ///////////////////
 
-    pub fn is_lead_head_allowed(&self, row: &Row, fixed_bells: &[(Bell, usize)]) -> bool {
-        self.allowed_lead_masks(fixed_bells)
+    pub fn is_lead_head_allowed(&self, row: &Row, params: &Parameters) -> bool {
+        self.allowed_lead_masks(params)
             .into_iter()
             .any(|m| m.matches(row))
     }
 
-    pub fn allowed_lead_masks(&self, fixed_bells: &[(Bell, usize)]) -> Vec<Mask> {
-        CourseSet::to_lead_masks(&self.allowed_courses, &self.inner, fixed_bells)
+    pub fn allowed_lead_masks(&self, params: &Parameters) -> Vec<Mask> {
+        CourseSet::to_lead_masks(&self.allowed_courses, &self.inner, &params.fixed_bells())
+    }
+
+    pub fn specified_course_masks(&self, params: &Parameters) -> Vec<Mask> {
+        CourseSet::to_course_masks(&self.allowed_courses, &self.inner, &params.fixed_bells())
     }
 }
 
@@ -631,7 +635,7 @@ impl CourseSet {
     /// Convert many `CourseSet`s into the corresponding course head [`Mask`]s.
     pub(crate) fn to_course_masks(
         allowed_courses: &[CourseSet],
-        method: &Method,
+        method: &bellframe::Method,
         fixed_bells: &[(Bell, usize)],
     ) -> Vec<Mask> {
         allowed_courses

--- a/monument/lib/src/prove_length.rs
+++ b/monument/lib/src/prove_length.rs
@@ -230,9 +230,14 @@ type SimpleChunk = (RowIdx, Mask);
 /// if it weren't cyclic, there'd be only 7 'chunks' per method (one for each position of the
 /// tenor).  Otherwise, we'd have 720 or 5040 chunks to process.
 fn compute_simplified_graph(query: &Query, graph: &Graph) -> SimpleGraph {
+    let allowed_lead_masks: MethodVec<_> = query
+        .methods
+        .iter()
+        .map(|m| m.allowed_lead_masks(&query.parameters))
+        .collect();
     let get_simple_chunks = |chunk_id: &ChunkId| -> Vec<SimpleChunk> {
         let mut simple_chunks = Vec::new();
-        for mask in &query.methods[chunk_id.row_idx.method].allowed_lead_masks {
+        for mask in &allowed_lead_masks[chunk_id.row_idx.method] {
             if mask.matches(&chunk_id.lead_head) {
                 simple_chunks.push((chunk_id.row_idx, mask.clone()));
             }

--- a/monument/lib/src/query.rs
+++ b/monument/lib/src/query.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, Range};
 
-use bellframe::{Block, RowBuf};
+use bellframe::RowBuf;
 use itertools::Itertools;
 
 use crate::{
@@ -12,21 +12,12 @@ use crate::{
     utils::PerPartLength,
 };
 
-/// Extra data precomputed from a set of [`Parameters`], to be used while generating the graph.
-///
-/// This is required because using the [`Parameters`] directly in a search is not useful for two
-/// major reasons:
-///
-/// 1. To allow the GUI to edit the [`Parameters`] directly, it is highly useful to be able to
-///    include methods/calls/music types in a set of [`Parameters`] but then mark them as 'unused'.
-///    However, the graph build and search algorithms only care about which methods are used, so
-///    in a [`Query`] we can do that filtering and provide cheap access to only used
-///    methods/calls/music types.
-///
-/// 2. We want to pre-compute and cache useful data which is used often in the core algorithms.  We
-///    don't want to add this 'derived' data directly into [`Parameters`] directly, since the
-///    consumer of the API would have to keep internal data up-to-date.  By putting it in `Query`,
-///    we can precompute them and provide them to the rest of the code.
+/// To allow the GUI to edit the [`Parameters`] directly, it is highly useful to be able to
+/// include methods/calls/music types in a set of [`Parameters`] but then mark them as 'unused'.
+/// However, the graph build and search algorithms only care about which methods are used, so
+/// in a [`Query`] we can do that filtering and provide cheap access to only used
+/// methods/calls/music types.
+// TODO: Fully remove this
 #[derive(Debug)]
 pub(crate) struct Query {
     pub parameters: Parameters,
@@ -39,9 +30,6 @@ pub(crate) struct Query {
 #[derive(Debug)]
 pub(crate) struct Method {
     pub inner: crate::parameters::Method,
-    /// A [`Block`] containing the entire plain course of `inner`.  Each row is annotated with the
-    /// labels assigned to that row.
-    pub plain_course: Block<Vec<String>>,
 }
 
 impl Query {
@@ -175,10 +163,6 @@ impl Query {
 
 impl Method {
     fn new(method: crate::parameters::Method) -> Self {
-        let plain_course = method.plain_course().map_annots(|a| a.labels.to_vec());
-        Self {
-            plain_course,
-            inner: method,
-        }
+        Self { inner: method }
     }
 }

--- a/monument/lib/src/query.rs
+++ b/monument/lib/src/query.rs
@@ -1,15 +1,12 @@
-use std::{
-    collections::HashSet,
-    ops::{Deref, Range},
-};
+use std::ops::{Deref, Range};
 
-use bellframe::{Bell, Block, Mask, Row, RowBuf, Stage};
+use bellframe::{Block, RowBuf};
 use itertools::Itertools;
 
 use crate::{
     graph::ChunkId,
     parameters::{
-        CallVec, CourseSet, MethodId, MethodIdx, MethodVec, MusicType, MusicTypeId, MusicTypeVec,
+        Call, CallVec, MethodId, MethodIdx, MethodVec, MusicType, MusicTypeId, MusicTypeVec,
         Parameters,
     },
     utils::PerPartLength,
@@ -34,7 +31,7 @@ use crate::{
 pub(crate) struct Query {
     pub parameters: Parameters,
     pub methods: MethodVec<Method>,
-    pub calls: CallVec<crate::parameters::Call>,
+    pub calls: CallVec<Call>,
     pub music_types: MusicTypeVec<MusicType>,
 }
 
@@ -45,13 +42,6 @@ pub(crate) struct Method {
     /// A [`Block`] containing the entire plain course of `inner`.  Each row is annotated with the
     /// labels assigned to that row.
     pub plain_course: Block<Vec<String>>,
-
-    /// The expanded version of `inner.allowed_courses`
-    pub specified_course_head_masks: Vec<Mask>,
-    /// The [`Mask`]s which lead heads must satisfy in order to be a lead head within
-    /// [`crate::SearchBuilder::courses`].
-    // TODO: Remove this
-    pub allowed_lead_masks: Vec<Mask>,
 }
 
 impl Query {
@@ -172,19 +162,9 @@ impl Query {
             .filter(|mt| mt.used)
             .cloned()
             .collect();
-        // Generate fixed bells
-        let fixed_bells = fixed_bells(
-            &used_methods,
-            used_calls.as_raw_slice(),
-            &parameters.start_row,
-            parameters.stage,
-        );
 
         Self {
-            methods: used_methods
-                .into_iter()
-                .map(|m| Method::new(m, &fixed_bells))
-                .collect(),
+            methods: used_methods.into_iter().map(Method::new).collect(),
             calls: used_calls,
             music_types: used_music_types,
 
@@ -194,97 +174,11 @@ impl Query {
 }
 
 impl Method {
-    fn new(method: crate::parameters::Method, fixed_bells: &[(Bell, usize)]) -> Self {
+    fn new(method: crate::parameters::Method) -> Self {
         let plain_course = method.plain_course().map_annots(|a| a.labels.to_vec());
         Self {
             plain_course,
-
-            specified_course_head_masks: CourseSet::to_course_masks(
-                &method.allowed_courses,
-                &method,
-                fixed_bells,
-            ),
-            allowed_lead_masks: CourseSet::to_lead_masks(
-                &method.allowed_courses,
-                &method,
-                fixed_bells,
-            ),
-
             inner: method,
-        }
-    }
-}
-
-//////////////////
-// FIXING BELLS //
-//////////////////
-
-/// Returns the place bells which are always preserved by plain leads and all calls of all methods
-/// (e.g. hunt bells in non-variable-hunt compositions).
-pub(super) fn fixed_bells(
-    methods: &[crate::parameters::Method],
-    calls: &[crate::parameters::Call],
-    start_row: &Row,
-    stage: Stage,
-) -> Vec<(Bell, usize)> {
-    let mut fixed_bells = stage.bells().collect_vec();
-    for m in methods {
-        let f = fixed_bells_of_method(m, calls);
-        fixed_bells.retain(|b| f.contains(b));
-    }
-    // Currently, these `fixed_bells` assume that the start_row is rounds
-    fixed_bells
-        .iter()
-        .map(|b| (start_row[b.index()], b.index()))
-        .collect_vec()
-}
-
-/// Returns the place bells which are always preserved by plain leads and all calls of a single
-/// method (e.g. hunt bells in non-variable-hunt compositions).
-fn fixed_bells_of_method(
-    method: &bellframe::Method,
-    calls: &[crate::parameters::Call],
-) -> HashSet<Bell> {
-    // Start the set with the bells which are fixed by the plain lead of every method
-    let mut fixed_bells: HashSet<Bell> = method.lead_head().fixed_bells().collect();
-    for call in calls {
-        // For each call, remove the bells which aren't fixed by that call (e.g. the 2 in
-        // Grandsire is unaffected by a plain lead, but affected by calls)
-        filter_bells_fixed_by_call(method, call, &mut fixed_bells);
-    }
-    fixed_bells
-}
-
-// For every position that this call could be placed, remove any bells which **aren't** preserved
-// by placing the call at this location.
-fn filter_bells_fixed_by_call(
-    method: &bellframe::Method,
-    call: &crate::parameters::Call,
-    set: &mut HashSet<Bell>,
-) {
-    // Note that all calls are required to only substitute one piece of place notation.
-    for sub_lead_idx_after_call in method.label_indices(&call.label_from) {
-        // TODO: Handle different from/to locations
-        let idx_before_call = (sub_lead_idx_after_call + method.lead_len() - 1) % method.lead_len();
-        let idx_after_call = idx_before_call + 1; // in range `1..=method.lead_len()`
-
-        // The row before a call in this location in the _first lead_
-        let row_before_call = method.first_lead().get_row(idx_before_call).unwrap();
-        // The row after a plain call in this location in the _first lead_
-        let row_after_no_call = method.first_lead().get_row(idx_after_call).unwrap();
-        // The row after a call in this location in the _first lead_
-        let mut row_after_call = row_before_call.to_owned();
-        call.place_notation.permute(&mut row_after_call).unwrap();
-
-        // A bell is _affected_ by the call iff it's in a different place in `row_after_call` than
-        // `row_after_no_call`.  These should be removed from the set, because they are no longer
-        // fixed.
-        for (bell_after_no_call, bell_after_call) in
-            row_after_no_call.bell_iter().zip(&row_after_call)
-        {
-            if bell_after_call != bell_after_no_call {
-                set.remove(&bell_after_call);
-            }
         }
     }
 }

--- a/monument/lib/src/query.rs
+++ b/monument/lib/src/query.rs
@@ -6,8 +6,8 @@ use itertools::Itertools;
 use crate::{
     graph::ChunkId,
     parameters::{
-        Call, CallVec, MethodId, MethodIdx, MethodVec, MusicType, MusicTypeId, MusicTypeVec,
-        Parameters,
+        Call, CallVec, Method, MethodId, MethodIdx, MethodVec, MusicType, MusicTypeId,
+        MusicTypeVec, Parameters,
     },
     utils::PerPartLength,
 };
@@ -24,12 +24,6 @@ pub(crate) struct Query {
     pub methods: MethodVec<Method>,
     pub calls: CallVec<Call>,
     pub music_types: MusicTypeVec<MusicType>,
-}
-
-// TODO: Remove this and calculate the values manually
-#[derive(Debug)]
-pub(crate) struct Method {
-    pub inner: crate::parameters::Method,
 }
 
 impl Query {
@@ -117,14 +111,6 @@ impl Deref for Query {
     }
 }
 
-impl Deref for Method {
-    type Target = crate::parameters::Method;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
 /////////////////////////
 // BUILDING EXTRA DATA //
 /////////////////////////
@@ -137,7 +123,7 @@ impl Query {
             .iter()
             .filter(|m| m.used)
             .cloned()
-            .collect_vec();
+            .collect();
         let used_calls: CallVec<_> = parameters
             .maybe_unused_calls
             .iter()
@@ -152,17 +138,11 @@ impl Query {
             .collect();
 
         Self {
-            methods: used_methods.into_iter().map(Method::new).collect(),
+            methods: used_methods,
             calls: used_calls,
             music_types: used_music_types,
 
             parameters,
         }
-    }
-}
-
-impl Method {
-    fn new(method: crate::parameters::Method) -> Self {
-        Self { inner: method }
     }
 }

--- a/monument/lib/src/search/mod.rs
+++ b/monument/lib/src/search/mod.rs
@@ -93,7 +93,7 @@ impl Search {
     }
 
     pub fn methods(&self) -> impl Iterator<Item = (&crate::parameters::Method, String)> {
-        self.query.methods.iter().map(|m| (&m.inner, m.shorthand()))
+        self.query.methods.iter().map(|m| (m, m.shorthand()))
     }
 
     pub fn music_type_ids(&self) -> impl Iterator<Item = MusicTypeId> + '_ {

--- a/monument/lib/src/utils/mod.rs
+++ b/monument/lib/src/utils/mod.rs
@@ -49,7 +49,7 @@ impl<Item, Dist: Ord> Ord for FrontierItem<Item, Dist> {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum Boundary {
+pub enum Boundary {
     Start,
     End,
 }


### PR DESCRIPTION
Instead of caching useful data (plain courses, fixed bells, lead masks, etc.) in `monument::query::Query`, we compute them on the fly and cache them locally if needed for performance.  This is the first step to removing `Query` entirely, thus removing one layer of indirection (and the associated cognitive overhead) from the code base.