### PR TITLE
Later memory check

### DIFF
--- a/monument/cli/src/args.rs
+++ b/monument/cli/src/args.rs
@@ -39,7 +39,7 @@ pub struct Options {
     #[structopt(long)]
     pub graph_size_limit: Option<usize>,
     /// The maximum number of bytes of heap memory that Monument's search routine can allocate.
-    /// Defaults to 80% of what's available.
+    /// Defaults to 80% of what's available.  E.g. `-M 10G` will limit memory to 10 gigabytes.
     #[structopt(short = "M", long, parse(try_from_str = parse_big_int))]
     pub mem_limit: Option<usize>,
 

--- a/monument/cli/src/toml_file.rs
+++ b/monument/cli/src/toml_file.rs
@@ -248,14 +248,12 @@ impl TomlFile {
     pub fn config(&self, opts: &crate::args::Options, leak_search_memory: bool) -> Config {
         let mut config = Config {
             thread_limit: opts.num_threads,
+            mem_limit: opts.mem_limit,
             leak_search_memory,
             ..Default::default()
         };
         if let Some(limit) = opts.graph_size_limit.or(self.graph_size_limit) {
             config.graph_size_limit = limit;
-        }
-        if let Some(limit) = opts.mem_limit {
-            config.mem_limit = limit;
         }
         config
     }

--- a/monument/lib/src/search/mod.rs
+++ b/monument/lib/src/search/mod.rs
@@ -204,7 +204,7 @@ pub struct Config {
     /* Search */
     /// The maximum number of bytes of heap memory which the search routine is allowed to use.
     /// Defaults to 80% of available memory.
-    pub mem_limit: usize,
+    pub mem_limit: Option<usize>,
     /// If `true`, the data structures used by searches will be leaked using [`std::mem::forget`].
     /// This massively improves the termination speed (because the search creates tons of small
     /// allocations which we now don't need to explicitly free) but only makes sense for the CLI,
@@ -215,29 +215,33 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
-        // Use as a memory limit either 80% of available memory or 5GB if we can't access
-        // availability
-        let ideal_mem_limit = if sysinfo::System::IS_SUPPORTED {
-            (sysinfo::System::new_all().available_memory() as f32 * 0.8) as u64
-        } else {
-            5_000_000_000u64
-        };
-        // However, always use 500MB less than the memory that's accessible by the system (i.e. if
-        // we're running in 32-bit environments like WASM, we can't fill available memory so we
-        // just default to `2*32 - 500MB ~= 3.5GB`)
-        let pointer_size_limit = (usize::MAX as u64).saturating_sub(500_000_000);
-        let mem_limit: usize = ideal_mem_limit
-            .min(pointer_size_limit)
-            .try_into()
-            .expect("Memory limit should fit into `usize`");
-
         Self {
             thread_limit: None,
 
             graph_size_limit: 100_000,
 
-            mem_limit,
+            mem_limit: None,
             leak_search_memory: false,
         }
     }
+}
+
+/// Return the memory limit for this search, if not specified by the user's [`Config`].  On most
+/// systems, this will return 80% of available memory.
+fn default_mem_limit() -> usize {
+    // Use as a memory limit either 80% of available memory or 5GB if we can't access
+    // availability
+    let ideal_mem_limit = if sysinfo::System::IS_SUPPORTED {
+        (sysinfo::System::new_all().available_memory() as f32 * 0.8) as u64
+    } else {
+        5_000_000_000u64
+    };
+    // However, always use 500MB less than the memory that's accessible by the system (i.e. if
+    // we're running in 32-bit environments like WASM, we can't fill available memory so we
+    // just default to `2*32 - 500MB ~= 3.5GB`)
+    let pointer_size_limit = (usize::MAX as u64).saturating_sub(500_000_000);
+    ideal_mem_limit
+        .min(pointer_size_limit)
+        .try_into()
+        .expect("Memory limit should fit into `usize`")
 }


### PR DESCRIPTION
Check memory usage just before the search starts.  This way, any system memory left by the allocator by earlier stages (e.g. graph build) will be factored in when determining how much is available.