### PR TITLE
Add filters to tests

### DIFF
--- a/monument/test/src/bench.rs
+++ b/monument/test/src/bench.rs
@@ -28,7 +28,7 @@ fn run() -> anyhow::Result<()> {
         common::load_results::<'_, Duration>(LAST_DURATIONS_PATH, &mut String::new())?;
     // Load benchmarks
     let mut unrun_cases =
-        common::load_cases(&["bench/"], "test/ignore.toml", |path, _| CaseData {
+        common::load_cases(&["bench/"], "test/ignore.toml", None, |path, _| CaseData {
             pinned_duration: pinned_durations.remove(path),
             last_duration: last_durations.remove(path),
         })?;

--- a/monument/test/src/test.rs
+++ b/monument/test/src/test.rs
@@ -57,6 +57,9 @@ fn main() -> anyhow::Result<()> {
 
 #[derive(StructOpt)]
 struct Args {
+    /// Only tests who's paths match this regex will be run
+    #[structopt(long, short = "F")]
+    filter: Option<String>,
     #[structopt(subcommand)]
     sub_command: Option<SubCommand>,
 }


### PR DESCRIPTION
Adds the `--filter` or `-F` option to apply a regex filter over which tests are run or blessed.  E.g.:
- `cargo test --test integration -- -F "examples/.*"` will only run the examples
- `cargo bless --fails -F "examples/.*"` will only bless the examples (leaving all other results unchanged).