### PR TITLE
Say `Generated 1 composition`

### DIFF
--- a/monument/cli/src/lib.rs
+++ b/monument/cli/src/lib.rs
@@ -166,8 +166,9 @@ impl SearchResult {
         }
         println!("{}", self.comp_printer.footer_lines());
         eprintln!(
-            "{} compositions generated{} {}",
+            "{} composition{} generated{} {}",
             self.comps.len(),
+            if self.comps.len() == 1 { "" } else { "s" }, // Handle "1 composition"
             match self.aborted {
                 true => ", aborted after",
                 false => " in",

--- a/monument/test/cases/1-comp.toml
+++ b/monument/test/cases/1-comp.toml
@@ -1,0 +1,3 @@
+length = "practice"
+method = "Cambridge Surprise Major"
+base_calls = "none"

--- a/monument/test/results.toml
+++ b/monument/test/results.toml
@@ -17,6 +17,13 @@
 "examples/snap-start.toml" = ''
 "examples/spicy-calls.toml" = ''
 "examples/spliced.toml" = ''
+"test/cases/1-comp.toml" = '''
+len |  music       4-bell runs      5678s     8765s     6578s    87s | avg score | calling
+----|----------------------------------------------------------------|-----------|-----------
+224 |   37.00 :   15 (  3f  12b)    0f  6b    0f  0b    0f  0b     0 |  0.165179 | 
+----|----------------------------------------------------------------|-----------|-----------
+len |  music       4-bell runs      5678s     8765s     6578s    87s | avg score | calling
+'''
 "test/cases/87s-at-back.toml" = '''
 len |  music     87s | avg score | calling
 ----|----------------|-----------|-----------


### PR DESCRIPTION
Previously, if one composition was generated, Monument would say "1 compositions generated".  Now, it drops the 's'.